### PR TITLE
Bugfix - Name Capitalization Rules Too Broad

### DIFF
--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -188,7 +188,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         if ($action === 'add') {
-            $username = strtolower(trim($_POST['username'] ?? ''));
+            $username = trim($_POST['username'] ?? '');
             $email    = trim($_POST['email'] ?? '');
             $role     = in_array($_POST['role'] ?? '', ['admin', 'user']) ? $_POST['role'] : 'user';
             $password = $_POST['password'] ?? '';
@@ -344,7 +344,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     // Support both full export format and simple username,email,phone,role,notes
                     // Detect by header: if first col is 'id' treat as full export (skip col 0)
                     $offset = (isset($header[0]) && strtolower(trim($header[0])) === 'id') ? 1 : 0;
-                    $username = strtolower(trim($row[$offset] ?? ''));
+                    $username = trim($row[$offset] ?? '');
                     $email    = strtolower(trim($row[$offset + 1] ?? ''));
                     $phone    = trim($row[$offset + 2] ?? '');
                     $role     = in_array(trim($row[$offset + 3] ?? ''), ['admin','user']) ? trim($row[$offset + 3]) : 'user';

--- a/www/admin_settings_dl.php
+++ b/www/admin_settings_dl.php
@@ -144,7 +144,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         if ($action === 'add') {
-            $username = strtolower(trim($_POST['username'] ?? ''));
+            $username = trim($_POST['username'] ?? '');
             $email    = trim($_POST['email'] ?? '');
             $role     = in_array($_POST['role'] ?? '', ['admin', 'user']) ? $_POST['role'] : 'user';
             $password = $_POST['password'] ?? '';

--- a/www/api/v1/events.php
+++ b/www/api/v1/events.php
@@ -394,7 +394,7 @@ function handle_events_post(): void {
         foreach ($resolved_invitees as $inv) {
             $ins->execute([
                 $new_eid,
-                strtolower($inv['username']),
+                $inv['username'],
                 $inv['phone'] ?: null,
                 $inv['email'] ?: null,
                 $inv['role'],
@@ -1000,7 +1000,7 @@ function handle_events_invites_post(): void {
             $next_sort++;
             $ins->execute([
                 $event_id,
-                $uname_lower,
+                $u['username'],
                 $u['phone'] ?: null,
                 $u['email'] ?: null,
                 $role,

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -122,7 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $phone_norm = $phone_raw !== '' ? normalize_phone($phone_raw) : '';
             $token = bin2hex(random_bytes(16));
             $sortOrd = $inv_sort_orders[$i] ?? ($i + 1);
-            $ins->execute([$eid, strtolower($inv_usernames[$i]), $phone_norm ?: null, $email_raw ?: null, $rsvp, $token, $invite_occ_date, $role, $sortOrd]);
+            $ins->execute([$eid, $inv_usernames[$i], $phone_norm ?: null, $email_raw ?: null, $rsvp, $token, $invite_occ_date, $role, $sortOrd]);
             // Only track new invitees for base (all-occurrence) saves so notifications go out
             if (!$invite_occ_date && !in_array(strtolower($inv_usernames[$i]), $old_names, true)) {
                 $new_usernames[] = strtolower($inv_usernames[$i]);
@@ -560,7 +560,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $baseRow = $baseStmt->fetch();
                     $baseApproval = $on_behalf ? 'approved' : ($baseRow['approval_status'] ?? 'approved');
                     $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, rsvp_token, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
-                       ->execute([$eid, strtolower($target_username), $baseRow['phone'] ?? null, $baseRow['email'] ?? null, $rsvp, bin2hex(random_bytes(16)), $occDate, $baseApproval]);
+                       ->execute([$eid, $target_username, $baseRow['phone'] ?? null, $baseRow['email'] ?? null, $rsvp, bin2hex(random_bytes(16)), $occDate, $baseApproval]);
                 }
             } else {
                 // Base RSVP (non-recurring or updating all-occurrence default)
@@ -614,7 +614,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Self-signup: approval gate fires if the event has requires_approval=1.
                 $approval = invite_approval_status($eid, 'self');
                 $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, rsvp_token, approval_status) VALUES (?, ?, ?, ?, NULL, ?, ?)')
-                   ->execute([$eid, strtolower($current['username']), $udata['phone'] ?? null, $udata['email'] ?? null, bin2hex(random_bytes(16)), $approval]);
+                   ->execute([$eid, $current['username'], $udata['phone'] ?? null, $udata['email'] ?? null, bin2hex(random_bytes(16)), $approval]);
                 db_log_activity($current['id'], "signed up for event id: $eid" . ($approval === 'pending' ? ' (pending approval)' : ''));
                 if ($approval === 'pending') {
                     $signup_pending = true;
@@ -626,7 +626,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
         if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
-            $inv = ['username' => strtolower($current['username']), 'rsvp' => null, 'approval_status' => $signup_pending ? 'pending' : 'approved'];
+            $inv = ['username' => $current['username'], 'rsvp' => null, 'approval_status' => $signup_pending ? 'pending' : 'approved'];
             if ($isAdmin) { $inv['phone'] = $udata['phone'] ?? null; $inv['email'] = $udata['email'] ?? null; }
             header('Content-Type: application/json');
             echo json_encode(['ok' => true, 'invite' => $inv, 'pending' => $signup_pending]);

--- a/www/calendar_dl.php
+++ b/www/calendar_dl.php
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $role = in_array($inv_roles[$i] ?? '', ['invitee', 'manager'], true) ? $inv_roles[$i] : 'invitee';
             $phone_norm = $inv_phones[$i] !== '' ? normalize_phone($inv_phones[$i]) : '';
             $sortOrd = $inv_sort_orders[$i] ?? ($i + 1);
-            $ins->execute([$eid, strtolower($inv_usernames[$i]), $phone_norm ?: null, $inv_emails[$i] ?: null, $rsvp, $role, $sortOrd]);
+            $ins->execute([$eid, $inv_usernames[$i], $phone_norm ?: null, $inv_emails[$i] ?: null, $rsvp, $role, $sortOrd]);
         }
     };
 
@@ -280,11 +280,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $form_inv     = [];
                 for ($i = 0; $i < count($inv_usernames); $i++) {
                     if ($inv_usernames[$i] === '') continue;
-                    $uname      = strtolower(trim($inv_usernames[$i]));
-                    $form_inv[] = $uname;
+                    $uname      = trim($inv_usernames[$i]);
+                    $form_inv[] = strtolower($uname);
                     $rsvp       = in_array($inv_rsvps[$i] ?? '', $valid_rsvps, true) ? ($inv_rsvps[$i] ?: null) : null;
                     $pnorm      = $inv_phones[$i] !== '' ? normalize_phone($inv_phones[$i]) : '';
-                    $is_new     = !in_array($uname, $old_inv, true);
+                    $is_new     = !in_array(strtolower($uname), $old_inv, true);
                     // New mid-series invitees on recurring events get valid_from = today
                     $vf = ($isRecurring && $is_new) ? $today_date : null;
                     $ins_base->execute([$id, $uname, $pnorm ?: null, $inv_emails[$i] ?: null, $rsvp, $vf]);
@@ -526,7 +526,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $base_row2 = $base_stmt2->fetch() ?: [];
                     $base_approval2 = $base_row2['approval_status'] ?? 'approved';
                     $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?)')
-                       ->execute([$eid, strtolower($current['username']), $base_row2['phone'] ?? null, $base_row2['email'] ?? null, $rsvp, $occ_date, $base_approval2]);
+                       ->execute([$eid, $current['username'], $base_row2['phone'] ?? null, $base_row2['email'] ?? null, $rsvp, $occ_date, $base_approval2]);
                 }
             } else {
                 // Non-recurring: update base row
@@ -561,7 +561,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Self-signup: approval gate fires if the event has requires_approval=1.
                 $approval = invite_approval_status($eid, 'self');
                 $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, approval_status) VALUES (?, ?, ?, ?, NULL, ?)')
-                   ->execute([$eid, strtolower($current['username']), $udata['phone'] ?? null, $udata['email'] ?? null, $approval]);
+                   ->execute([$eid, $current['username'], $udata['phone'] ?? null, $udata['email'] ?? null, $approval]);
                 db_log_activity($current['id'], "signed up for event id: $eid" . ($approval === 'pending' ? ' (pending approval)' : ''));
                 if ($approval === 'pending') {
                     $signup_pending = true;
@@ -572,7 +572,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
         if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] === 'XMLHttpRequest') {
-            $inv = ['username' => strtolower($current['username']), 'rsvp' => null, 'approval_status' => $signup_pending ? 'pending' : 'approved'];
+            $inv = ['username' => $current['username'], 'rsvp' => null, 'approval_status' => $signup_pending ? 'pending' : 'approved'];
             if ($isAdmin) { $inv['phone'] = $udata['phone'] ?? null; $inv['email'] = $udata['email'] ?? null; }
             header('Content-Type: application/json');
             echo json_encode(['ok' => true, 'invite' => $inv, 'pending' => $signup_pending]);


### PR DESCRIPTION
Hi - I'm Jeremy, a developer who picked up GameNight for a private group.
First-time contributor here, happy to find a project this close to what I needed.

## What this fixes

User display names were being lowercased on write in several places due to
`strtolower()` calls that were scoped too broadly - they were meant to normalize
emails but were also applied to the `name` field.

## Files changed

- `www/calendar.php`
- `www/calendar_dl.php`
- `www/admin_settings.php`
- `www/admin_settings_dl.php`
- `www/api/v1/events.php`

10 instances fixed across 5 files.

## Data migration note - read before merging

This fix corrects new writes going forward, but **existing rows in the `users`
and `event_invites` tables may already contain lowercased names** if they were
written by the affected code paths.

The `admin_settings.php` add-user path was also writing lowercase directly into
the `users` table, so some accounts may have been created with the wrong case
from the start.

No migration script is included in this PR. If your instance has existing users,
you may want to audit and correct the `name` column in both tables before or
after merging. Happy to help scope a migration if useful.