### PR TITLE
Fix: week and month view lose your place after saving an event

### DIFF
--- a/www/calendar.php
+++ b/www/calendar.php
@@ -914,7 +914,7 @@ if ($viewMode === 'week') {
 // In week view, derive the back-navigation month from the visible week rather than
 // the ?m= param (which is absent in week view). This ensures edit/add form redirects
 // return to the correct month instead of always defaulting to the current month.
-if ($viewMode === 'week' && $wkStart) {
+if ($viewMode === 'week' && $wkStart && $mParam === null) {
     $monthParam = $wkStart->format('Y-m');
 }
 

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -791,12 +791,24 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit;
     }
 
-    $back = $_POST['month_param'] ?? '';
-    // After add: navigate to the event's month so user can see it
+    $back_wk = $_POST['wk_param'] ?? '';
+    $back_m  = $_POST['month_param'] ?? '';
+    // After add: navigate to the event's week/month so user can see it
     if ($action === 'add' && !empty($sd)) {
-        $back = substr($sd, 0, 7);
+        if (!empty($back_wk)) {
+            // Came from week view - compute the Sunday of the event's start date
+            $evDt  = new DateTime($sd, $local_tz);
+            $evDow = (int)$evDt->format('w');
+            $back_wk = (clone $evDt)->modify("-{$evDow} days")->format('Y-m-d');
+        } else {
+            $back_m = substr($sd, 0, 7);
+        }
     }
-    header('Location: /calendar.php' . ($back ? '?m=' . urlencode($back) : ''));
+    if (!empty($back_wk)) {
+        header('Location: /calendar.php?wk=' . urlencode($back_wk));
+    } else {
+        header('Location: /calendar.php' . ($back_m ? '?m=' . urlencode($back_m) : ''));
+    }
     exit;
 }
 
@@ -898,6 +910,12 @@ if ($viewMode === 'week') {
     foreach ($wkAllEvents as &$_ev) { $_ev = event_display_times($_ev, $_site_tz, $local_tz); }
     unset($_ev);
     $wkByDate    = build_event_by_date($wkAllEvents, $wkStartStr, $wkEndStr, $local_tz);
+}
+// In week view, derive the back-navigation month from the visible week rather than
+// the ?m= param (which is absent in week view). This ensures edit/add form redirects
+// return to the correct month instead of always defaulting to the current month.
+if ($viewMode === 'week' && $wkStart) {
+    $monthParam = $wkStart->format('Y-m');
 }
 
 // Batch-load comments for all events on this page (month view, preview, and week view)
@@ -1816,6 +1834,7 @@ $token = ($isAdmin || $current) ? csrf_token() : '';
             <input type="hidden" name="action" id="eAction" value="add">
             <input type="hidden" name="id" id="eId" value="">
             <input type="hidden" name="month_param" value="<?= htmlspecialchars($monthParam) ?>">
+            <input type="hidden" name="wk_param" value="<?= $wkStart !== null ? htmlspecialchars($wkStartStr) : '' ?>">
             <input type="hidden" name="occurrence_date" id="eOccDate" value="">
             <input type="hidden" name="end_date" id="eEndDate" value="">
             <input type="hidden" name="end_time" id="eEndTime" value="">


### PR DESCRIPTION
## Problem

When adding or editing an event from week or month view, the post-save redirect always lands on the current week in week view. Two related causes:

1. Week view URLs use `?wk=` rather than `?m=`, so `$monthParam` is never populated when arriving from week view. The edit/add form's hidden `month_param` field carries an empty value, and the redirect handler falls back to today's month.

2. On a successful add, the redirect was unconditionally overwriting `$back` with the event's month - correct in month view, but in week view there was no mechanism to return to the originating week at all.

## Fix

Three changes, all in `calendar.php`:

**1. Derive `$monthParam` from the visible week in week view** (line ~914)

After the week's events are loaded and `$wkStart` is set, populate `$monthParam` from the week's start date. This ensures the hidden `month_param` field carries a useful value even when no `?m=` param is present in the URL.

**2. Add a `wk_param` hidden input to the event form** (line ~1835)

The form now carries the current week's start date alongside `month_param`. This gives the redirect handler enough context to know which view the user came from.

**3. Week-aware redirect logic in the POST handler** (line ~794)

The handler now reads both `wk_param` and `month_param`. If `wk_param` is set, it redirects back to week view (`?wk=`). On an add, it computes the Sunday of the new event's start date so the redirect lands on the week containing the event rather than the originating week. Month view behavior is unchanged.

## Behavior after fix

- Edit event in week view -> save -> returns to the same week
- Add event in week view -> save -> returns to the week containing the new event
- Add/edit in month view -> save -> unchanged, returns to the correct month

## Scope

One file changed (`www/calendar.php`), three hunks. No schema changes, no new dependencies.