### PR TITLE
Payouts tab follows the game type you pick, not the saved one (v0.2060)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2060] - 2026-08-08
+
+### Fixed
+- **The Payouts & Rewards tab stayed disabled until you saved the game type.** Setting up a new tournament meant choosing Tournament, saving, and then reopening Settings before the payout structure could be configured at all. The tab's disabled state is derived from `isCash()`, which reads the *saved* session, while `previewGameType()` — the dropdown's change handler — only showed and hid sections inside the panes and never touched the tab strip. It now updates both gated tabs live: Payouts enables and disables with the pending choice, and Tickets shows and hides with it. Switching back to Cash while sitting on Payouts returns you to the Game tab rather than leaving you on a dead tab with no panel showing.
+
+---
+
 ## [v0.2059] - 2026-08-07
 
 ### Added

--- a/www/checkin.php
+++ b/www/checkin.php
@@ -2110,6 +2110,32 @@ function previewGameType(val) {
         var el = document.getElementById(id);
         if (el) el.style.display = hide ? 'none' : '';
     });
+    // The Payouts & Rewards and Tickets tabs are gated on game type, which is
+    // read from the SAVED session when the editor renders. Without this, picking
+    // Tournament left both tabs dead until you saved and reopened — you had to
+    // save a game type before you could configure the payouts for it.
+    var payTab = document.querySelector('.pk-sv-tab[data-tab="payouts"]');
+    if (payTab) {
+        payTab.classList.toggle('disabled', hide);
+        if (hide) {
+            payTab.setAttribute('disabled', 'disabled');
+            payTab.setAttribute('title', 'Cash games have no payout structure');
+            payTab.onclick = null;
+            // Don't strand the user on a tab that just became unreachable.
+            if (SETTINGS_TAB === 'payouts') setSettingsTab('game');
+        } else {
+            payTab.removeAttribute('disabled');
+            payTab.removeAttribute('title');
+            payTab.onclick = function() { setSettingsTab('payouts'); };
+        }
+    }
+    // Tickets only exists when the game has already awarded some; hide rather
+    // than enable, since switching to cash makes it meaningless either way.
+    var tickTab = document.querySelector('.pk-sv-tab[data-tab="tickets"]');
+    if (tickTab) {
+        tickTab.style.display = hide ? 'none' : '';
+        if (hide && SETTINGS_TAB === 'tickets') setSettingsTab('game');
+    }
 }
 
 // ─── Reward feature toggles (progressive disclosure) ──────

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2059');
+define('APP_VERSION', '0.2060');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Reported from the Settings view: you couldn't get into **Payouts & Rewards** until you selected Tournament *and saved*.

**Cause.** The tab's disabled state is derived from `isCash()`, which reads the **saved** session. `previewGameType()` — the game-type dropdown's change handler — only showed and hid sections inside the panes and never touched the tab strip. So the tab stayed dead until a save round-tripped the new type back into `SESSION`.

That made setting up a new tournament awkward: choose Tournament, save, reopen Settings, *then* configure the payouts.

**Fix.** `previewGameType()` now updates both gated tabs live — Payouts enables/disables with the pending choice, Tickets shows/hides with it. And if the tab you're on becomes unreachable, you're moved back to Game rather than left on a dead tab with no panel showing.

**Verified on dev** against a cash game (event 150):

- tab disabled on arrival
- enabled the moment Tournament is picked, with no save
- a real click (no force) lands on the pane with the payout editor visible
- switching back to Cash re-disables it and returns to the Game tab
- no console errors