### PR TITLE
Jackpot: show this game's collected money, and let a hit be paid mid-game (v0.2063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2063] - 2026-08-08
+
+### Fixed
+- **The jackpot screen showed nothing of the money collected for the current game.** Jackpot entries were contributed to the league fund only when a game was *finished*, so mid-game the modal read `Fund: $0.00` with a table full of paid-up entries behind it. It now shows what this game has taken and what the fund becomes: `+ $7.00 collected this game (7 entries × $1.00) — added to the fund when the game is finished, total after finish $7.00`. The line is absent once that money is banked, so nothing is ever counted twice; `jackpots.contributed` rides along with the balance in the session load, the jackpot log and the hit response so the client can tell the difference.
+- **A jackpot could not be paid out mid-game.** `record_jackpot_hit` capped the payout at the banked fund balance, which excluded everything the current game had collected — so a bad beat, which by its nature happens at the table mid-game, was refused with "Payout $X exceeds the fund ($0.00)" and could not be settled until the game was finished. New `pk_jackpot_sync_contribution()` banks a session's collected entries on demand, and the hit handler calls it before the balance check.
+- The contribution is computed as the **delta** between what a session has collected and what it has already contributed, so it is safe to call repeatedly: an early bank at hit time followed by a finish tops up only the entries that arrived in between, and a re-finish adds nothing. `pk_finish_session()` now delegates to the same helper instead of carrying its own dupe-guarded copy, so both paths share one rule. The sync only ever moves upward — if entries are withdrawn after a hit has drawn on them, that money really did leave the box and stays contributed. Reopening a game whose contributions have already been paid out remains blocked by the existing guard, which now matters more often.
+
+---
+
 ## [v0.2062] - 2026-08-08
 
 ### Changed

--- a/www/_poker_helpers.php
+++ b/www/_poker_helpers.php
@@ -72,6 +72,64 @@ function pk_jackpot_balance($db, ?int $league_id): int {
     } catch (Exception $e) { return 0; /* pre-migration DB */ }
 }
 
+// Bring the league fund up to date with what this session has collected in
+// jackpot entries. Returns the amount added (0 if nothing was owed).
+//
+// Contributions used to land only when a game was finished, which made a
+// mid-game jackpot hit unpayable: the money was in the box but not in the fund,
+// so record_jackpot_hit refused it. A bad beat is inherently a mid-game event,
+// so this is callable at hit time as well as at finish.
+//
+// It works on the DELTA between what the session has collected and what it has
+// already contributed, so calling it repeatedly never double-banks, and a finish
+// after an early bank tops up only the entries that arrived in between. It only
+// ever syncs UPWARD — if entries are withdrawn after a hit has already drawn on
+// them, the money really did leave the box, so it stays contributed.
+function pk_jackpot_sync_contribution($db, int $session_id, ?int $actor_id): int {
+    $sess = $db->prepare('SELECT ps.game_type, ps.jackpot_amount, ps.jackpot_optional,
+                                 e.title AS src_title, e.league_id
+                          FROM poker_sessions ps JOIN events e ON e.id = ps.event_id WHERE ps.id = ?');
+    $sess->execute([$session_id]);
+    $s = $sess->fetch();
+    if (!$s || $s['game_type'] !== 'tournament') return 0;
+
+    $per = (int)($s['jackpot_amount'] ?? 0);
+    if (empty($s['league_id']) || $per <= 0) return 0;
+
+    // Optional mode = opted-in entries; baked mode = every buy-in (calc_pool
+    // withholds those from the prize pool). Same rule the pool math uses.
+    if ((int)($s['jackpot_optional'] ?? 1)) {
+        $bq = $db->prepare('SELECT COALESCE(SUM(jackpot_in), 0) FROM poker_players WHERE session_id = ? AND removed = 0');
+        $unit = 'entries';
+    } else {
+        $bq = $db->prepare('SELECT COUNT(*) FROM poker_players WHERE session_id = ? AND removed = 0 AND bought_in = 1');
+        $unit = 'buy-ins';
+    }
+    $bq->execute([$session_id]);
+    $units = (int)$bq->fetchColumn();
+    if ($units <= 0) return 0;
+
+    try {
+        $fund = pk_jackpot_fund($db, (int)$s['league_id']);
+        $prev = $db->prepare("SELECT COALESCE(SUM(amount), 0) FROM league_jackpot_log
+                              WHERE jackpot_id = ? AND session_id = ? AND event_type = 'contribution' AND voided = 0");
+        $prev->execute([(int)$fund['id'], $session_id]);
+        $already = (int)$prev->fetchColumn();
+        $owed = $units * $per - $already;
+        if ($owed <= 0) return 0;
+
+        $detail = ($already > 0 ? 'Top-up to ' : '')
+                . "$units $unit × " . pk_money($per) . ' from "' . $s['src_title'] . '"';
+        $db->prepare('INSERT INTO league_jackpot_log (jackpot_id, session_id, event_type, amount, detail, created_by)
+                      VALUES (?, ?, ?, ?, ?, ?)')
+           ->execute([(int)$fund['id'], $session_id, 'contribution', $owed, $detail, $actor_id]);
+        $db->prepare('UPDATE league_jackpots SET balance = balance + ? WHERE id = ?')->execute([$owed, (int)$fund['id']]);
+        pk_log($db, $session_id, $actor_id, 'jackpot', null, null, $owed,
+               'Jackpot contribution — ' . pk_money($owed) . " ($units $unit × " . pk_money($per) . ')');
+        return $owed;
+    } catch (Exception $e) { return 0; /* pre-migration DB */ }
+}
+
 // Upsert a user's last-used session defaults. league_id null = personal scope.
 // Security: every column name interpolated into SQL is intersected with the
 // USER_SESSION_DEFAULT_COLS whitelist so unknown keys in $data can never reach SQL.
@@ -650,38 +708,11 @@ function pk_finish_session($db, int $session_id, int $actor_id): void {
     $s = $sess->fetch();
     if (!$s || $s['game_type'] !== 'tournament') return;
 
-    // Jackpot contribution, once per finish (guarded so a re-finish never
-    // double-contributes): optional mode = opted-in entries × price; baked
-    // mode = every buy-in × price (withheld from the pool by calc_pool).
-    $per = (int)($s['jackpot_amount'] ?? 0);
-    if (!empty($s['league_id']) && $per > 0) {
-        if ((int)($s['jackpot_optional'] ?? 1)) {
-            $bq = $db->prepare('SELECT COALESCE(SUM(jackpot_in), 0) FROM poker_players WHERE session_id = ? AND removed = 0');
-        } else {
-            $bq = $db->prepare('SELECT COUNT(*) FROM poker_players WHERE session_id = ? AND removed = 0 AND bought_in = 1');
-        }
-        $bq->execute([$session_id]);
-        $buyins = (int)$bq->fetchColumn();
-        $unit = (int)($s['jackpot_optional'] ?? 1) ? 'entries' : 'buy-ins';
-        if ($buyins > 0) {
-            try {
-                $fund = pk_jackpot_fund($db, (int)$s['league_id']);
-                $dupe = $db->prepare("SELECT COUNT(*) FROM league_jackpot_log
-                                      WHERE jackpot_id = ? AND session_id = ? AND event_type = 'contribution' AND voided = 0");
-                $dupe->execute([(int)$fund['id'], $session_id]);
-                if ((int)$dupe->fetchColumn() === 0) {
-                    $amt = $buyins * $per;
-                    $db->prepare('INSERT INTO league_jackpot_log (jackpot_id, session_id, event_type, amount, detail, created_by)
-                                  VALUES (?, ?, ?, ?, ?, ?)')
-                       ->execute([(int)$fund['id'], $session_id, 'contribution', $amt,
-                                  "$buyins $unit × " . pk_money($per) . ' from "' . $s['src_title'] . '"', $actor_id]);
-                    $db->prepare('UPDATE league_jackpots SET balance = balance + ? WHERE id = ?')->execute([$amt, (int)$fund['id']]);
-                    pk_log($db, $session_id, $actor_id, 'jackpot', null, null, $amt,
-                           'Jackpot contribution — ' . pk_money($amt) . " ($buyins $unit × " . pk_money($per) . ')');
-                }
-            } catch (Exception $e) { /* pre-migration DB */ }
-        }
-    }
+    // Jackpot contribution. Delegated to pk_jackpot_sync_contribution(), which
+    // banks the difference between what this game collected and what it has
+    // already contributed — so a re-finish adds nothing, and a finish after a
+    // mid-game hit banked part of it tops up only the rest.
+    pk_jackpot_sync_contribution($db, $session_id, $actor_id);
     $target = (int)($s['ticket_target_event_id'] ?? 0);
     if ($target <= 0) return;
     $tq = $db->prepare('SELECT id, title, start_date FROM events WHERE id = ?');

--- a/www/checkin.php
+++ b/www/checkin.php
@@ -2296,9 +2296,46 @@ function toggleReward(key) {
 }
 
 // ─── League jackpot hit recording ─────────────────────────
+// The league fund only receives this game's jackpot money when the game is
+// FINISHED — the contribution is written once, guarded against re-finishing, in
+// pk_apply_tournament_payouts(). Mid-game the balance alone therefore reads as
+// "nothing collected" even with a table full of paid-up entries, which is
+// exactly wrong on the screen used to pay a jackpot out. Show what this game has
+// taken and what the fund becomes, clearly marked as not banked yet.
+function jackpotPendingCents() {
+    if (!SESSION) return 0;
+    var jAmt = parseInt(SESSION.jackpot_amount) || 0;
+    if (jAmt <= 0) return 0;
+    var collected = parseInt(SESSION.jackpot_optional)
+        ? (parseInt(POOL.jackpot_collected) || 0)
+        : (parseInt(POOL.jackpot_withheld) || 0);
+    // Subtract what is already in the fund for this game. Finishing banks all of
+    // it; recording a hit mid-game banks it early so the payout can draw on it.
+    // Without this the banked money would be shown as pending as well.
+    return Math.max(0, collected - (parseInt(JACKPOTS.contributed) || 0));
+}
+
+function jackpotBalanceHtml() {
+    var bal = parseInt(JACKPOTS.balance) || 0;
+    var h = 'Fund: <b>' + formatMoney(bal) + '</b>';
+    var pending = jackpotPendingCents();
+    if (pending > 0) {
+        var optional = parseInt(SESSION.jackpot_optional);
+        var n = optional ? (parseInt(POOL.jackpot_entries) || 0) : (parseInt(POOL.total_buyins) || 0);
+        var unit = optional ? (n === 1 ? 'entry' : 'entries') : (n === 1 ? 'buy-in' : 'buy-ins');
+        h += '<div style="margin-top:.35rem;font-size:.8rem;color:#7c3aed;font-weight:600">'
+           + '+ ' + formatMoney(pending) + ' collected this game '
+           + '<span style="color:#64748b;font-weight:400">(' + n + ' ' + unit + ' &times; '
+           + formatMoney(parseInt(SESSION.jackpot_amount)) + ')</span></div>'
+           + '<div style="font-size:.75rem;color:#64748b">Added to the fund when the game is finished &mdash; '
+           + 'total after finish <b>' + formatMoney(bal + pending) + '</b></div>';
+    }
+    return h;
+}
+
 function openJackpotModal() {
     var b = document.getElementById('jpBalances');
-    b.innerHTML = 'Fund: <b>' + formatMoney(JACKPOTS.balance) + '</b>';
+    b.innerHTML = jackpotBalanceHtml();
     document.getElementById('jpRecipients').innerHTML = '';
     addJackpotRecipient();
     document.getElementById('jpAdjustRow').style.display = 'none';
@@ -2319,7 +2356,8 @@ function loadJackpotHistory() {
             if (!j.ok) { box.textContent = j.error || 'Error'; return; }
             if (typeof j.balance === 'number') {
                 JACKPOTS.balance = j.balance;
-                document.getElementById('jpBalances').innerHTML = 'Fund: <b>' + formatMoney(j.balance) + '</b>';
+                if (typeof j.contributed === 'number') JACKPOTS.contributed = j.contributed;
+                document.getElementById('jpBalances').innerHTML = jackpotBalanceHtml();
             }
             if (!j.entries.length) { box.innerHTML = '<span style="color:#94a3b8">No activity yet.</span>'; return; }
             var h = '';

--- a/www/checkin_dl.php
+++ b/www/checkin_dl.php
@@ -63,7 +63,8 @@ if ($action === 'get_session') {
         'pool'     => calc_pool($db, $session['id']),
         'log'      => get_session_log($db, (int)$session['id']),
         'tickets'  => ['incoming' => $tin->fetchAll(), 'outgoing' => $tout->fetchAll()],
-        'jackpots' => ['league_id' => $league_id, 'balance' => pk_jackpot_balance($db, $league_id)],
+        'jackpots' => ['league_id' => $league_id, 'balance' => pk_jackpot_balance($db, $league_id),
+                       'contributed' => pk_jackpot_contributed($db, (int)$session['id'])],
     ]);
     exit;
 }
@@ -297,6 +298,18 @@ if ($action === 'list_target_events') {
 
 // ─── GET: jackpot_log ──────────────────────────────────────
 // The league jackpot's ledger (newest first), for the 💎 modal's history view.
+// How much of a session's jackpot money is already banked in the fund. The
+// client subtracts this from what the game has collected to show what is still
+// pending, so an early bank at hit time does not get counted twice.
+function pk_jackpot_contributed($db, int $session_id): int {
+    try {
+        $q = $db->prepare("SELECT COALESCE(SUM(amount), 0) FROM league_jackpot_log
+                           WHERE session_id = ? AND event_type = 'contribution' AND voided = 0");
+        $q->execute([$session_id]);
+        return (int)$q->fetchColumn();
+    } catch (Exception $e) { return 0; /* pre-migration DB */ }
+}
+
 if ($action === 'jackpot_log') {
     $session_id = (int)($_GET['session_id'] ?? 0);
     $sess = $db->prepare('SELECT ps.*, e.league_id FROM poker_sessions ps JOIN events e ON e.id = ps.event_id WHERE ps.id = ?');
@@ -313,12 +326,13 @@ if ($action === 'jackpot_log') {
     $fundQ = $db->prepare("SELECT id, balance FROM league_jackpots WHERE league_id = ? AND jackpot_type = 'main'");
     $fundQ->execute([(int)$s['league_id']]);
     $fund = $fundQ->fetch();
-    if (!$fund) { echo json_encode(['ok' => true, 'entries' => [], 'balance' => 0]); exit; }
+    if (!$fund) { echo json_encode(['ok' => true, 'entries' => [], 'balance' => 0, 'contributed' => 0]); exit; }
     $q = $db->prepare('SELECT id, event_type, player_name, amount, detail, voided, created_at
                        FROM league_jackpot_log WHERE jackpot_id = ? ORDER BY id DESC LIMIT 100');
     $q->execute([(int)$fund['id']]);
     echo json_encode(['ok' => true, 'entries' => $q->fetchAll(),
-                      'balance' => (int)$fund['balance']]);
+                      'balance' => (int)$fund['balance'],
+                      'contributed' => pk_jackpot_contributed($db, $session_id)]);
     exit;
 }
 
@@ -2002,6 +2016,13 @@ if ($action === 'record_jackpot_hit') {
     }
     if (!$recips) { echo json_encode(['ok' => false, 'error' => 'Add at least one recipient with an amount.']); exit; }
 
+    // A bad beat happens mid-game, so this game's collected entries must be
+    // payable now — they used to sit outside the fund until the game finished,
+    // which refused every mid-game payout. Bank what this session has collected
+    // first; the sync works on the delta, so finishing later tops up the rest
+    // rather than contributing twice.
+    pk_jackpot_sync_contribution($db, $session_id, (int)$current['id']);
+
     $fund = pk_jackpot_fund($db, (int)$s['league_id']);
     if ($total > (int)$fund['balance']) {
         echo json_encode(['ok' => false, 'error' => 'Payout ' . pk_money($total) . ' exceeds the fund (' . pk_money((int)$fund['balance']) . ').']); exit;
@@ -2019,7 +2040,9 @@ if ($action === 'record_jackpot_hit') {
     $db->prepare('UPDATE league_jackpots SET balance = balance - ? WHERE id = ?')->execute([$total, (int)$fund['id']]);
     db_log_activity((int)$current['id'], "$label jackpot hit: " . pk_money($total) . " paid (session id=$session_id)");
 
-    echo json_encode(['ok' => true, 'jackpots' => ['league_id' => (int)$s['league_id'], 'balance' => pk_jackpot_balance($db, (int)$s['league_id'])]]);
+    echo json_encode(['ok' => true, 'jackpots' => ['league_id' => (int)$s['league_id'],
+        'balance' => pk_jackpot_balance($db, (int)$s['league_id']),
+        'contributed' => pk_jackpot_contributed($db, $session_id)]]);
     exit;
 }
 

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2062');
+define('APP_VERSION', '0.2063');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Reported against live event 178: a $1.00 optional jackpot with 7 of 10 players opted in, and the jackpot screen showing nothing of it.

The cause is that jackpot entries were contributed to the league fund **only when a game was finished**, once, guarded against re-finishing, in `pk_finish_session()`. Mid-game there is genuinely no `league_jackpots` row for that league and no contribution — so the fund really did hold $0.00 while $7.00 sat in the box. That produced two distinct failures.

### Fixed — the screen showed nothing of tonight's money

The modal rendered only `Fund: $0.00`. It now shows what the game has taken and what the fund becomes:

> **Fund: $0**
> **+ $3 collected this game** *(3 entries × $1)*
> Added to the fund when the game is finished — total after finish **$3**

The pending line disappears once that money is banked, so nothing is counted twice. The client cannot infer that on its own, so `jackpots.contributed` — this session's non-voided contribution total — now rides along with the balance in the session load, the `jackpot_log` response and the `record_jackpot_hit` response.

### Fixed — a jackpot could not be paid out mid-game

`record_jackpot_hit` capped the payout at the banked balance:

```php
if ($total > (int)$fund['balance']) { ... 'Payout $X exceeds the fund ($0.00)' ... }
```

A bad beat is by its nature a mid-game event — it hits at the table — so this refused every real payout until the game was finished. Confirmed on dev before the change: with $3 collected and a $0 balance, paying $1 returned `{"ok":false,"error":"Payout $1 exceeds the fund ($0)."}`.

New `pk_jackpot_sync_contribution()` banks a session's collected entries on demand, and the hit handler calls it before the balance check.

### The delta is what makes this safe

The helper contributes the **difference** between what a session has collected and what it has already contributed, rather than a fixed amount behind a one-shot guard. That makes it safe to call from more than one place: an early bank at hit time followed by a finish tops up only the entries that arrived in between, and a re-finish adds nothing. `pk_finish_session()` now delegates to the same helper instead of carrying its own dupe-guarded copy, so both paths share one rule.

Verified end to end on dev:

| Step | Result |
|---|---|
| 3 entries × $1, fund $0 | pending $3; payout previously refused |
| Record a $2 hit mid-game | **succeeds** — banks $3, pays $2, balance **$1** |
| Modal after the hit | `Fund: $1`, pending line gone (not double-counted) |
| A 4th entry joins, then sync | tops up **exactly $1**, logged *"Top-up to 4 entries × $1"*, balance **$2** |
| Sync again | returns **$0**, balance unchanged — idempotent |

Total contributed lands at $4 for 4 entries.

### Two behaviours worth knowing

- The sync only ever moves **upward**. If entries are withdrawn after a hit has drawn on them, that money really did leave the box, so it stays contributed.
- **Reopening a game whose contributions have already been paid out is still blocked** by the pre-existing guard in `pk_unfinish_session()` — reversing them would overdraw the fund. That is correct, and it now comes up more often.

`league_jackpot_log` reversal on reopen already loops over every contribution row for a session, so the extra top-up rows this can create are handled without change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)