### PR TITLE
League in Game Setup, shared segmented control, preset-bar fixes (v0.2064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2064] - 2026-08-08
+
+### Added
+- **The event's league can be set from Game Setup.** Jackpot funds and saved payout presets both belong to a league, so configuring a jackpot on an event with no league hit "Jackpots are league funds — this event must belong to a league first" and the only way forward was to leave Setup, edit the event, and come back. A League field now sits left of Game Type and saves with everything else. Server-side it is applied *before* the jackpot validation, so a league and a jackpot can be set in a single save. Authorization mirrors the event editor exactly: binding an event to a league takes owner or manager of **that** league, or site admin — membership alone is not enough. The event's current league is always shown, marked, even to a co-host with no role on it. A game that has already banked or paid jackpot money cannot change league: that money is held in one league's fund, and moving the event would leave the two apart.
+
+### Changed
+- **Setup's tabs are the segmented control with the sliding thumb**, matching the toolbar's view and filter strips, and the pane slides in from the side the thumb travelled. An underlined-tab strip was a third idiom for the same gesture. Disabled tabs (a cash game has no payout structure) are dimmed and do not light up on hover, and the thumb is re-measured whenever a segment is shown, hidden, enabled or disabled — the widths move even when the selection does not.
+- **The segmented control is now shared, not page-local.** Styles moved to `style.css` and behaviour to a new `pk-seg.js` that `_footer.php` loads on every page, so any page can use the pattern with no per-page wiring. `positionAllSegThumbs()` scans every `.pk-seg[id]` rather than three hardcoded ids, and the `resize` re-measure moved into the shared file. `pk-seg.js` is deliberately not deferred: a page may put its own inline `<script>` after the footer, as `checkin.php` does, and must see the functions already defined. Documented in CLAUDE.md as the preferred switcher for future work, with the rules that keep it from breaking.
+- **The "this game isn't set up yet" prompt is amber, not blue.** In the informational palette it read as a tip and disappeared into the page; it now uses the app's warning colours with a heavier left bar and a warning glyph, matching the ticket-target warning and the seat cutoff divider.
+
+### Fixed
+- **The Game Preset bar was unreachable on a cash game.** It was rendered only when the *saved* game type was tournament, and `previewGameType()` did not touch it — so choosing Tournament in the dropdown revealed the tournament fields and the Payouts tab but not the presets, and they could not be reached until the game type had been saved and the editor reopened. Same defect the Payouts tab had in v0.2060. The section is now always rendered and hidden by game type, and the preset list is populated for both types so a revealed select is not empty.
+- **Loading a preset threw away an unsaved game-type choice.** `loadPayoutStructure()` redraws through `renderDashboard()` and `refreshSettingsView()`, both of which rebuild the pane from the saved session — so picking Tournament on a game still saved as cash and then loading a preset snapped the dropdown back to Cash and hid everything that choice had revealed, including the preset bar just used. The pending choice is now captured before the redraw and re-applied after.
+- **Stylesheet edits between releases served stale CSS.** `style.css` was cache-busted on `APP_VERSION` alone, so any change to it between version bumps kept browsers on their cached copy. It now carries the file's mtime as well, the same guard `pk-dialogs.js` already used, across all 54 pages that link it. This surfaced when shared rules moved out of a page's inline `<style>` into `style.css`: the rules were gone from the page and not yet in the cached stylesheet, so the segmented control lost its styling and animation entirely.
+
+---
+
 ## [v0.2063] - 2026-08-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,54 @@ Schema and migrations live entirely in `db_init()` inside `www/db.php`. New colu
 - Security headers (CSP, X-Frame-Options, etc.) are set in `auth.php` and applied globally
 - RSVP tokens allow one-click RSVP without login (stored in `event_invites.rsvp_token`)
 
+## UI Conventions
+
+### Segmented control + slide — the preferred switcher
+
+**When a user picks between sibling views, panes or filters, use the segmented control with the sliding thumb, and slide the new content in behind it.** This is the house style: prefer it over tab strips, underlined tabs, radio groups or plain button rows. It is in use on the check-in console's view strip, its player filter, and the Setup editor's tabs — new switchers should match rather than invent a fourth idiom.
+
+Styles are in `www/style.css` and behaviour in `www/pk-seg.js`, which `_footer.php` loads on every page — so any page can use this, no per-page wiring:
+
+| Piece | Where | What it does |
+|---|---|---|
+| `.pk-seg` + `.pk-seg-thumb` | `style.css` | the pill track and the accent-filled thumb |
+| `.pk-seg.thumb-off` | `style.css` | hides the thumb when the selection lives outside the control |
+| `positionSegThumb(segId, animate)` | `pk-seg.js` | measures the active button and moves the thumb. `animate: false` on a fresh render (nothing moved), `true` on a user click |
+| `positionAllSegThumbs(animate)` | `pk-seg.js` | re-measures every `.pk-seg[id]` on the page; already wired to `resize` |
+| `segTravelDirection(segId, attr, from, to)` | `pk-seg.js` | which way the thumb travelled, `1` right / `-1` left. Reads the **live** button order, so an absent segment doesn't break it |
+| `slideViewIn(el, dir)` | `pk-seg.js` | slides the newly-shown content in from that side |
+
+Markup contract:
+
+```html
+<div class="pk-seg" id="mySeg">
+  <span class="pk-seg-thumb"></span>
+  <button data-x="a" class="active">A</button>
+  <button data-x="b">B</button>
+</div>
+```
+
+`pk-seg.js` is loaded **without `defer`** on purpose: a page may put its own inline `<script>` after the footer (`checkin.php` does) and must see these already defined.
+
+Note `_admin_tabs.php` is a different thing and should stay as it is — those tabs are links to separate *pages*, not an in-page switcher.
+
+Timings are deliberate and shared: **thumb `.2s`**, **content `.32s`**, both `cubic-bezier(.4,0,.2,1)`. Don't introduce new durations for the same gesture.
+
+Rules that keep it from breaking:
+
+- **Content enters from the side the thumb travelled.** Never a fixed direction — that is what makes it read as movement rather than a flicker.
+- **Re-measure the thumb whenever the strip's widths change**, not only when the selection changes: a segment being shown, hidden, enabled or disabled all move the buttons.
+- **A hidden control measures zero.** `positionSegThumb()` bails when the element isn't rendered, so it never writes a zero-width thumb over a good position. Position *after* a control becomes visible, not before.
+- **Don't replay the animation when the value didn't change** (a re-render or a click on the already-active segment).
+- **Reduced motion is handled centrally** — `@media (prefers-reduced-motion: reduce)` sets `animation: none`, and `slideViewIn()` has a timeout fallback because `animationend` never fires in that case. Reuse the helper and you get this for free.
+
+### Other UI conventions
+
+- **Amber means warning, blue means information.** Warnings use `#fffbeb` / `#f59e0b` / `#92400e` (see `.pk-setup-cta`, the ticket-target warning, the seat-cutoff divider). A warning styled in blue reads as a tip and gets ignored.
+- **Never `margin-left: auto` in a wrapping flex row.** It pins to the right end of whichever *line* the element lands on, so the element drifts between rows as the window resizes. Group the row's children instead so it breaks in one deliberate place.
+- Full pages over modals for multi-step flows.
+- All dialogs go through the `pk*` helpers in `pk-dialogs.js` — never native `alert`/`confirm`/`prompt`. Use `pkCopy()` for clipboard writes; `navigator.clipboard` is undefined outside a secure context and throws synchronously.
+
 ## Dates & Times
 
 - All dates stored in UTC

--- a/www/SMTPTesting.php
+++ b/www/SMTPTesting.php
@@ -64,7 +64,7 @@ $configured     = $smtp_host && $smtp_username && $smtp_password && $smtp_from;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .smtp-grid { display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; }
         @media (max-width:640px) { .smtp-grid { grid-template-columns:1fr; } }

--- a/www/_footer.php
+++ b/www/_footer.php
@@ -73,6 +73,11 @@ if ($_hb_user && empty($_hb_user['timezone'])) {
     <?php
 }
 ?>
+<?php /* Segmented control + slide engine. Deliberately NOT deferred: a page may
+         put its own inline <script> after this footer (checkin.php does), and it
+         must see these functions already defined. Tiny, and already at the end
+         of the body, so blocking is a non-issue. */ ?>
+<script src="/pk-seg.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/pk-seg.js') ?: 0)) ?>"></script>
 <?php /* filemtime cache-buster: pk-dialogs.js changes must reach browsers even
          between version bumps (a stale copy silently breaks pk* callers). */ ?>
 <script src="/pk-dialogs.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/pk-dialogs.js') ?: 0)) ?>" defer></script>

--- a/www/_league_denied.php
+++ b/www/_league_denied.php
@@ -18,7 +18,7 @@ $reason = $denyReason ?? 'hidden_non_member';
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>League not available &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .deny-wrap { max-width: 640px; margin: 2.5rem auto; padding: 0 1rem; }
         .deny-card { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 12px; padding: 2rem 1.75rem; text-align: center; }

--- a/www/admin_api_keys.php
+++ b/www/admin_api_keys.php
@@ -64,7 +64,7 @@ function api_keys_admin_fmt(?string $utc_dt, DateTimeZone $local_tz): string {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Keys — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .ak-card { background:#fff; border:1.5px solid #e2e8f0; border-radius:10px; padding:1.25rem; margin-bottom:1rem; }
         .ak-table { width:100%; border-collapse:collapse; font-size:.875rem; }

--- a/www/admin_help.php
+++ b/www/admin_help.php
@@ -47,7 +47,7 @@ $tips = $tipsStmt->fetchAll();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Help Tips &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .hlp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; align-items: start; }
         @media (max-width: 760px) { .hlp-grid { grid-template-columns: 1fr; } }

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -205,7 +205,7 @@ $now_local = (new DateTime('now', $local_tz))->format('Y-m-d H:i:s');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <link href="/vendor/jodit/jodit.min.css" rel="stylesheet">
     <style>
         .hint { font-size: .78rem; color: #94a3b8; margin-top: .35rem; }

--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -833,7 +833,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .hint { font-size: .78rem; color: #94a3b8; margin-top: .35rem; }
         .pk-toggle-input { display:none; }

--- a/www/admin_settings_dl.php
+++ b/www/admin_settings_dl.php
@@ -480,7 +480,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .hint { font-size: .78rem; color: #94a3b8; margin-top: .35rem; }
 

--- a/www/admin_tickets.php
+++ b/www/admin_tickets.php
@@ -33,7 +33,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Support Tickets &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .at-wrap { max-width: 900px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .at-table { width: 100%; border-collapse: collapse; font-size: .875rem; background: #fff; border: 1.5px solid #e2e8f0; border-radius: 10px; overflow: hidden; }

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -1023,7 +1023,7 @@ $editorCtx = ($wkStart !== null) ? 'wk=' . urlencode($wkStartStr) : 'm=' . urlen
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
 
         .cal-header {

--- a/www/checkin.php
+++ b/www/checkin.php
@@ -20,6 +20,35 @@ if (!can_manage_event($db, (int)$event_id, (int)$current['id'], $isAdmin)) {
 $site_name = get_setting('site_name', 'Game Night');
 $csrf = csrf_token();
 
+// Leagues this host may bind the event to, for the League select in Setup.
+// Same rule the server enforces in update_config: owner/manager of that league,
+// or site admin. The event's CURRENT league is always included even without a
+// role on it, so a co-host can see where the game sits (and re-save) without
+// being able to move it somewhere new.
+$assignable_leagues = [];
+$_curLeague = (int)($event['league_id'] ?? 0);
+foreach (user_leagues((int)$current['id']) as $_lg) {
+    if (in_array($_lg['role'], ['owner', 'manager'], true)) {
+        $assignable_leagues[(int)$_lg['id']] = $_lg['name'];
+    }
+}
+if ($isAdmin) {
+    foreach ($db->query('SELECT id, name FROM leagues ORDER BY LOWER(name)') as $_lg) {
+        $assignable_leagues[(int)$_lg['id']] = $_lg['name'];
+    }
+}
+// Anyone holding a role on a league can also unbind the event (set None), so the
+// picker is offered whenever they have at least one — even if that one is the
+// league the event is already on.
+$_canMoveLeague = $isAdmin || count($assignable_leagues) > 0;
+// The current league is always listed, even without a role on it, so a co-host
+// can see where the game sits. Marked so it doesn't read as a free choice.
+if ($_curLeague && !isset($assignable_leagues[$_curLeague])) {
+    $_lgName = $db->prepare('SELECT name FROM leagues WHERE id = ?');
+    $_lgName->execute([$_curLeague]);
+    $assignable_leagues[$_curLeague] = ($_lgName->fetchColumn() ?: 'League #' . $_curLeague) . ' (current)';
+}
+
 // Walk-in autocomplete suggestions. Admins see every site username; non-admins see only
 // usernames they would already have access to via the event editor's invite picker:
 // the event's league roster (if any) plus their personal contacts.
@@ -69,7 +98,7 @@ $session = $sessStmt->fetch();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Manage Game — <?= htmlspecialchars($event['title']) ?> — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
     .pk-wrap{padding:0 1rem 2rem;max-width:100%}
     .pk-header{background:var(--dark,#0f172a);color:#fff;padding:.75rem 1.5rem;display:flex;align-items:center;gap:1.5rem;flex-wrap:wrap;position:sticky;top:0;z-index:50}
@@ -141,13 +170,9 @@ $session = $sessStmt->fetch();
     .pk-help-content h4{margin:.9rem 0 .25rem;font-size:.9rem;color:#0f172a}
     .pk-help-content h4:first-child{margin-top:0}
     .pk-help-content p{margin:0;font-size:.85rem;color:#475569;line-height:1.45}
-    /* Shared "pill slider" segmented control — used by the player filter and the view switcher
-       so the two read as matched grouped controls. A thumb slides under the active button. */
-    .pk-seg{position:relative;display:inline-flex;border:1.5px solid #cbd5e1;border-radius:8px;background:#dde3ec;padding:3px;box-shadow:inset 0 1px 2px rgba(15,23,42,.14)}
-    .pk-seg-thumb{position:absolute;top:3px;bottom:3px;left:0;width:0;border-radius:6px;background:var(--accent,#2563eb);box-shadow:0 1px 3px rgba(37,99,235,.5);z-index:0;transition:transform .2s cubic-bezier(.4,0,.2,1),width .2s cubic-bezier(.4,0,.2,1)}
-    .pk-seg button{position:relative;z-index:1;border:none;background:transparent;cursor:pointer;padding:.34rem .75rem;font-size:.76rem;font-weight:600;color:#475569;white-space:nowrap;transition:color .15s}
-    .pk-seg button:hover:not(.active){color:#1e293b}
-    .pk-seg button.active{color:#fff}
+    /* .pk-seg / .pk-seg-thumb / the slide-in keyframes now live in style.css,
+       with the behaviour in pk-seg.js — see CLAUDE.md "UI Conventions". Only
+       page-specific tweaks to the control belong here. */
 
     .pk-table-wrap{overflow-x:auto;border:1.5px solid var(--border,#e2e8f0);border-radius:8px;background:var(--surface,#fff)}
     .pk-table{width:100%;border-collapse:collapse;font-size:.85rem}
@@ -212,35 +237,21 @@ $session = $sessStmt->fetch();
         box-shadow:0 1px 2px rgba(15,23,42,.08);transition:background .15s,color .15s}
     .pk-toolbar .pk-btn-setup:hover{background:#eff6ff}
     .pk-toolbar .pk-btn-setup.active{background:var(--accent,#2563eb);color:#fff;box-shadow:0 1px 3px rgba(37,99,235,.5)}
-    /* When Setup is the active view no segment is selected, so hide the thumb
-       rather than leaving it parked under a button that isn't current. */
-    .pk-view-seg.thumb-off .pk-seg-thumb{opacity:0}
 
     /* "This game isn't set up yet" prompt — the loudest signal, shown only
-       while it's true and gone the moment the game is configured. */
+       while it's true and gone the moment the game is configured. Amber, not
+       blue: in blue it read as an informational tip and disappeared into the
+       page. This is the app's warning palette, matching the ticket-target
+       warning and the seat-cutoff divider. */
     .pk-setup-cta{display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin:0 0 .6rem;padding:.7rem .9rem;
-        background:#eff6ff;border:1.5px solid #bfdbfe;border-radius:8px}
-    .pk-setup-cta-txt{flex:1 1 240px;min-width:0;font-size:.82rem;color:#1e3a8a;line-height:1.4}
-    .pk-setup-cta-txt b{display:block;font-size:.9rem;color:#1e40af}
-    .pk-setup-cta button{flex:0 0 auto;border:none;background:var(--accent,#2563eb);color:#fff;border-radius:6px;
+        background:#fffbeb;border:1.5px solid #f59e0b;border-left-width:5px;border-radius:8px}
+    .pk-setup-cta-txt{flex:1 1 240px;min-width:0;font-size:.82rem;color:#92400e;line-height:1.4}
+    .pk-setup-cta-txt b{display:block;font-size:.9rem;color:#b45309}
+    .pk-setup-cta button{flex:0 0 auto;border:none;background:#d97706;color:#fff;border-radius:6px;
         padding:.45rem 1rem;font-size:.82rem;font-weight:700;cursor:pointer}
+    .pk-setup-cta button:hover{background:#b45309}
 
-    /* View transitions — the content slides in from the side the thumb travelled,
-       on the thumb's easing curve. Deliberately slower than the thumb's .2s: the
-       content is a far larger object covering the same distance, and matching the
-       thumb exactly made it feel snapped rather than slid. Enter-only: animating
-       the outgoing view too would need both stacked, doubling page height mid-swap. */
-    @keyframes pkViewInRight{from{opacity:0;transform:translateX(26px)}to{opacity:1;transform:none}}
-    @keyframes pkViewInLeft{from{opacity:0;transform:translateX(-26px)}to{opacity:1;transform:none}}
-    .pk-view-in-right{animation:pkViewInRight .32s cubic-bezier(.4,0,.2,1)}
-    .pk-view-in-left{animation:pkViewInLeft .32s cubic-bezier(.4,0,.2,1)}
-    /* `clip` rather than `hidden`: it doesn't create a scroll container, so the
-       26px offset can't flash a horizontal scrollbar. Removed on animationend
-       so the Table view keeps its own horizontal scrolling. */
-    .pk-view-animating{overflow-x:clip}
-    @media(prefers-reduced-motion:reduce){
-        .pk-view-in-right,.pk-view-in-left{animation:none}
-    }
+    /* View/pane transitions live in style.css — see pk-seg.js. */
     .pk-pv-sub{font-size:.8rem;color:#64748b;margin:0 0 .6rem}
     /* Cards stack in the content column; the sidebar keeps its own cards in
        the position they hold on every other view. */
@@ -271,10 +282,23 @@ $session = $sessStmt->fetch();
     .pk-sv-title #svSaved{color:#16a34a;font-size:.8rem;font-weight:600;margin-left:.4rem}
     .pk-sv-save{padding:.45rem 1.4rem;background:var(--accent,#2563eb);color:#fff;border:none;border-radius:6px;font-weight:600;font-size:.85rem;cursor:pointer}
     .pk-sv-close{padding:.45rem 1rem;background:transparent;color:#64748b;border:1.5px solid var(--border,#e2e8f0);border-radius:6px;font-weight:600;font-size:.85rem;cursor:pointer}
-    .pk-sv-tabs{display:flex;gap:.25rem;padding:0 1.25rem;border-bottom:1.5px solid var(--border,#e2e8f0);flex-shrink:0}
-    .pk-sv-tab{padding:.55rem .9rem;border:none;background:transparent;font-size:.85rem;font-weight:600;color:#64748b;cursor:pointer;border-bottom:2.5px solid transparent;margin-bottom:-1.5px}
-    .pk-sv-tab.active{color:var(--accent,#2563eb);border-bottom-color:var(--accent,#2563eb)}
-    .pk-sv-tab.disabled{opacity:.4;cursor:default}
+    /* Setup's tabs are the same segmented control as the toolbar sliders, thumb
+       and all. They switch between panes exactly like the view strip switches
+       between views, so an underlined-tab idiom here was a third way of saying
+       the same thing. Buttons keep .pk-sv-tab so the gating code that enables
+       and disables them by data-tab is unchanged. */
+    .pk-sv-tabs{display:flex;padding:.6rem 1.25rem;border-bottom:1.5px solid var(--border,#e2e8f0);flex-shrink:0}
+    .pk-sv-seg{max-width:100%;flex-wrap:wrap}
+    .pk-sv-seg .pk-sv-tab{padding:.42rem .9rem;font-size:.82rem}
+    /* Disabled (cash game has no payout structure) must not look selectable, and
+       must not light up on hover the way a live segment does. */
+    .pk-sv-seg .pk-sv-tab.disabled,
+    .pk-sv-seg .pk-sv-tab:disabled{opacity:.4;cursor:default}
+    .pk-sv-seg .pk-sv-tab.disabled:hover,
+    .pk-sv-seg .pk-sv-tab:disabled:hover{color:#475569}
+    /* On the active segment the thumb is behind the label, so the amber badge
+       needs to hold up against the accent fill rather than the grey track. */
+    .pk-sv-seg .pk-sv-tab.active .pk-sv-badge{background:#fff;color:#b45309}
     .pk-sv-badge{background:#fde68a;color:#92400e;border-radius:999px;font-size:.68rem;padding:.05rem .4rem;font-weight:700}
     /* Was flex:1 inside a full-height fixed overlay; inline it grows with its
        content and the page scrolls, like every other view. */
@@ -732,6 +756,13 @@ var CSRF = <?= json_encode($csrf, JSON_HEX_TAG) ?>;
 var ALL_USERS = <?= json_encode($allUsernames, JSON_HEX_TAG) ?>;
 var EVENT_ID = <?= $event_id ?>;
 var EVENT_LEAGUE_ID = <?= (int)($event['league_id'] ?? 0) ?>;
+var ASSIGNABLE_LEAGUES = <?= json_encode(array_map(
+        function ($id, $name) { return ['id' => (int)$id, 'name' => $name]; },
+        array_keys($assignable_leagues), array_values($assignable_leagues)
+    ), JSON_HEX_TAG) ?>;
+// A co-host with no league role anywhere can see the binding but must not be
+// offered a change — the server refuses it, so don't present it as possible.
+var CAN_MOVE_LEAGUE = <?= $_canMoveLeague ? 'true' : 'false' ?>;
 var IS_ADMIN = <?= $isAdmin ? 'true' : 'false' ?>;
 var SESSION = <?= $session ? json_encode($session, JSON_HEX_TAG) : 'null' ?>;
 var PAYOUT_STRUCTURES = [];
@@ -1673,7 +1704,7 @@ function renderSetupCta() {
     // Don't nag while they're already in the editor doing it.
     if (SETTINGS_OPEN || VIEW_MODE === 'settings') return '';
     var h = '<div class="pk-setup-cta">';
-    h += '<div class="pk-setup-cta-txt"><b>&#9881; This game isn\'t set up yet</b>';
+    h += '<div class="pk-setup-cta-txt"><b>&#9888; This game isn\'t set up yet</b>';
     h += 'Set the ' + (isTourney() ? 'buy-in, chips, rebuys, payouts and rewards' : 'buy-in and table rules')
        + ' before players start buying in, so the money and prizes add up.';
     if (isTourney() && !(PAYOUTS || []).length) h += ' No payout structure is set yet.';
@@ -1908,11 +1939,14 @@ function openSettings(tab) {
     SETTINGS_OPEN = true;
     SETTINGS_DIRTY = false;
     setViewMode('settings', true);   // force: SETTINGS_TAB may have changed
+    // The preset list is populated for BOTH game types: the bar is rendered
+    // (hidden) on a cash session so switching the dropdown to Tournament can
+    // reveal a select that already has its options.
+    // First open fetches the saved-structure list; later opens must still
+    // re-render it into the freshly-built (empty) select.
+    if (!PAYOUT_STRUCTURES.length) loadPayoutStructures();
+    else renderPayoutStructureSelect();
     if (isTourney()) {
-        // First open fetches the saved-structure list; later opens must still
-        // re-render it into the freshly-built (empty) select.
-        if (!PAYOUT_STRUCTURES.length) loadPayoutStructures();
-        else renderPayoutStructureSelect();
         populateTicketTargetSelect();
         updateBountyHint();
     }
@@ -1931,6 +1965,7 @@ async function closeSettings() {
 document.addEventListener('keydown', function(e) { if (e.key === 'Escape' && SETTINGS_OPEN) closeSettings(); });
 
 function setSettingsTab(tab) {
+    var prev = SETTINGS_TAB;
     SETTINGS_TAB = tab;
     document.querySelectorAll('.pk-sv-tab').forEach(function(t) {
         t.classList.toggle('active', t.getAttribute('data-tab') === tab);
@@ -1938,6 +1973,14 @@ function setSettingsTab(tab) {
     document.querySelectorAll('.pk-sv-pane').forEach(function(p) {
         p.classList.toggle('active', p.getAttribute('data-pane') === tab);
     });
+    positionSegThumb('settingsSeg', true);   // animate: the thumb is moving
+    // Slide the newly-shown pane in from the side the thumb travelled, exactly
+    // as the views do. Skipped when the tab did not actually change, so a
+    // re-render or a redundant click doesn't replay the animation.
+    if (prev !== tab) {
+        slideViewIn(document.querySelector('.pk-sv-pane[data-pane="' + tab + '"]'),
+                    segTravelDirection('settingsSeg', 'data-tab', prev, tab));
+    }
 }
 
 function markSettingsDirty() {
@@ -1953,13 +1996,25 @@ function markSettingsDirty() {
 // actions), preserving the active tab and open state.
 function refreshSettingsView() {
     if (!SETTINGS_OPEN) return;
+    // The pane is rebuilt from the SAVED session, so an unsaved game-type choice
+    // would be thrown away — and with it the sections that choice reveals. That
+    // is what made the preset bar vanish the moment a preset was loaded on a
+    // game still saved as cash: load re-renders, the dropdown snapped back, and
+    // the bar you had just used hid itself.
+    var pendingType = (document.getElementById('cfg_game_type') || {}).value || '';
     var vc = document.getElementById('viewContent');
     if (vc) vc.innerHTML = renderSettingsView();
+    var typeSel = document.getElementById('cfg_game_type');
+    if (typeSel && pendingType && pendingType !== typeSel.value) {
+        typeSel.value = pendingType;
+        previewGameType(pendingType);
+    }
+    renderPayoutStructureSelect();
     if (isTourney()) {
-        renderPayoutStructureSelect();
         populateTicketTargetSelect();
         updateBountyHint();
     }
+    positionSegThumb('settingsSeg', false);   // the strip was just rebuilt
 }
 
 function renderSettingsView() {
@@ -1977,20 +2032,28 @@ function renderSettingsView() {
     h += '<button class="pk-sv-close" onclick="closeSettings()">Close</button>';
     h += '</div></div>';
 
-    // Tab strip
+    // Tab strip — a segmented control with a sliding thumb, same as the toolbar.
     h += '<div class="pk-sv-tabs">';
+    h += '<div class="pk-seg pk-sv-seg" id="settingsSeg">';
+    h += '<span class="pk-seg-thumb"></span>';
     h += '<button class="pk-sv-tab' + (SETTINGS_TAB === 'game' ? ' active' : '') + '" data-tab="game" onclick="setSettingsTab(\'game\')">Game</button>';
     h += '<button class="pk-sv-tab' + (SETTINGS_TAB === 'payouts' ? ' active' : '') + (isCash() ? ' disabled' : '') + '" data-tab="payouts" ' + (isCash() ? 'disabled title="Cash games have no payout structure"' : 'onclick="setSettingsTab(\'payouts\')"') + '>Payouts &amp; Rewards</button>';
     if (hasTickets && !isCash()) {
         h += '<button class="pk-sv-tab' + (SETTINGS_TAB === 'tickets' ? ' active' : '') + '" data-tab="tickets" onclick="setSettingsTab(\'tickets\')">Tickets <span class="pk-sv-badge">' + TICKETS.outgoing.length + '</span></button>';
     }
     h += '</div>';
+    h += '</div>';
 
     // Scrolling body: all panes mounted, active one visible. The preset bar
     // sits ABOVE the panes because a preset restores BOTH tabs.
     h += '<div class="pk-sv-body">';
-    if (!isCash()) {
-        h += '<div class="pk-cfg-section" style="border-top:none;padding-top:0;margin-top:0"><div class="pk-cfg-title" style="display:flex;align-items:center;gap:.45rem">Game Preset'
+    // Rendered for BOTH game types and hidden by previewGameType() when cash, so
+    // switching the dropdown to Tournament reveals it immediately. It used to be
+    // omitted from the markup entirely on a cash session, which meant presets
+    // could not be reached until the game type had been saved and the editor
+    // reopened — the same defect the Payouts tab had.
+    {
+        h += '<div class="pk-cfg-section" id="cfgPresetSection" style="border-top:none;padding-top:0;margin-top:0' + (isCash() ? ';display:none' : '') + '"><div class="pk-cfg-title" style="display:flex;align-items:center;gap:.45rem">Game Preset'
            + '<button class="pk-help-btn" style="padding:.15rem .5rem;font-size:.7rem" title="What game presets do" aria-label="Game preset help" onclick="showPresetHelp()">?</button></div>';
         h += '<div style="display:flex;gap:.5rem;align-items:center;flex-wrap:wrap">';
         h += '<select id="payoutStructureSelect" onchange="onPayoutStructureChange()" style="flex:0 1 300px;min-width:160px;padding:.3rem .5rem;border:1.5px solid var(--border,#e2e8f0);border-radius:4px;font-size:.85rem"></select>';
@@ -2027,6 +2090,30 @@ function renderGamePane() {
     // ── Game ──
     h += '<div class="pk-cfg-section"><div class="pk-cfg-title">Game</div>';
     h += '<div class="pk-settings-grid">';
+    // League first: jackpots are league funds and payout presets are scoped to a
+    // league, so hitting "this event must belong to a league" used to mean
+    // leaving Setup for the event editor and coming back. Saved with everything
+    // else by Save, and applied before the jackpot check server-side so a league
+    // and a jackpot can be set in one go.
+    h += '<div><label>League ' + tip('Jackpot funds and saved payout presets belong to a league. Changing this moves the event.') + '</label>';
+    if (CAN_MOVE_LEAGUE) {
+        h += '<select id="cfg_league_id" onchange="markSettingsDirty()">';
+        h += '<option value="0"' + (!EVENT_LEAGUE_ID ? ' selected' : '') + '>&mdash; None &mdash;</option>';
+        for (var li = 0; li < ASSIGNABLE_LEAGUES.length; li++) {
+            var lg = ASSIGNABLE_LEAGUES[li];
+            h += '<option value="' + lg.id + '"' + (parseInt(EVENT_LEAGUE_ID) === lg.id ? ' selected' : '') + '>' + escHtml(lg.name) + '</option>';
+        }
+        h += '</select>';
+    } else {
+        // No league role anywhere: show the binding, don't offer to change it.
+        var curName = '';
+        for (var lj = 0; lj < ASSIGNABLE_LEAGUES.length; lj++) {
+            if (ASSIGNABLE_LEAGUES[lj].id === parseInt(EVENT_LEAGUE_ID)) curName = ASSIGNABLE_LEAGUES[lj].name;
+        }
+        h += '<div style="padding:.4rem 0;font-size:.85rem;color:#64748b">' + (curName ? escHtml(curName) : 'None')
+           + '<br><span style="font-size:.72rem">Only a league owner or manager can change this.</span></div>';
+    }
+    h += '</div>';
     h += '<div><label>Game Type</label><select id="cfg_game_type" onchange="previewGameType(this.value)"><option value="tournament"' + (isTourney()?' selected':'') + '>Tournament</option><option value="cash"' + (isCash()?' selected':'') + '>Cash Game</option></select></div>';
     h += '<div><label>Buy-in</label><div class="pk-money-wrap"><input type="number" id="cfg_buyin" value="' + Math.round(parseInt(SESSION.buyin_amount)/100) + '" step="1" min="0" oninput="updateBountyHint()"></div></div>';
     h += '</div></div>';
@@ -2229,7 +2316,7 @@ function payoutForPlace(place) {
 
 function previewGameType(val) {
     var hide = val === 'cash';
-    ['cfgTourneyFields', 'cfgPayoutSection', 'ticketsPanel', 'cfgRewardsSection'].forEach(function(id) {
+    ['cfgTourneyFields', 'cfgPayoutSection', 'ticketsPanel', 'cfgRewardsSection', 'cfgPresetSection'].forEach(function(id) {
         var el = document.getElementById(id);
         if (el) el.style.display = hide ? 'none' : '';
     });
@@ -2259,6 +2346,9 @@ function previewGameType(val) {
         tickTab.style.display = hide ? 'none' : '';
         if (hide && SETTINGS_TAB === 'tickets') setSettingsTab('game');
     }
+    // Showing or hiding a segment changes the strip's widths, so the thumb has
+    // to be re-measured even when the active tab itself did not change.
+    positionSegThumb('settingsSeg', true);
 }
 
 // ─── Reward feature toggles (progressive disclosure) ──────
@@ -2697,10 +2787,21 @@ function loadPayoutStructure() {
             POOL = j.pool || POOL;
             if (j.session) SESSION = j.session;  // recipe presets update bounty/jackpot too
             CURRENT_STRUCTURE_ID = parseInt(sid);
+            // Capture an unsaved game-type choice BEFORE the redraw. Both
+            // renderDashboard() and refreshSettingsView() rebuild the pane from
+            // the SAVED session, so picking Tournament on a game still saved as
+            // cash and then loading a preset used to snap the dropdown back and
+            // hide the preset bar you had just used.
+            var pendingType = (document.getElementById('cfg_game_type') || {}).value || '';
             // Redraw: the editor re-renders in place (keeps tab + open state),
             // and the dashboard refreshes underneath it.
             renderDashboard();
             refreshSettingsView();
+            var typeSel = document.getElementById('cfg_game_type');
+            if (typeSel && pendingType && pendingType !== typeSel.value) {
+                typeSel.value = pendingType;
+                previewGameType(pendingType);
+            }
         })
         .catch(function() { pkProgressDone(); pkAlert('Request failed'); });
 }
@@ -2987,80 +3088,30 @@ function setViewMode(mode, force) {
     // The unconfigured prompt hides inside the editor and comes back on exit.
     var cta = document.getElementById('setupCta');
     if (cta) cta.innerHTML = renderSetupCta();
-    // The filter bar is rebuilt with the view, so its thumb starts unpositioned.
-    // No animation: it is a brand-new element, not one that moved. Balance and
-    // Add Table are rendered inside that bar, so they need no toggling here.
+    // Freshly-rendered controls start with an unpositioned thumb. No animation:
+    // these are brand-new elements, not ones that moved. Balance and Add Table
+    // are rendered inside the filter bar, so they need no toggling here.
     if (filterApplies(mode)) positionSegThumb('filterSeg', false);
+    if (mode === 'settings') positionSegThumb('settingsSeg', false);
     if (mode === 'log') { renderLog(); fetchLog(); }
     else if (mode !== 'payouts') { updateBulkBar(); }
 }
 
-// Which way the thumb travels between two views, so the content can enter from
-// the same side. Reads the live button order rather than a hardcoded list, so
-// it stays right when a segment is absent (cash games have no Payouts/Chop).
+// segTravelDirection() / slideViewIn() / positionSegThumb() / positionAllSegThumbs()
+// live in pk-seg.js, loaded for every page by _footer.php. Only the page's own
+// rule about where Setup sits belongs here.
 function segDirection(fromMode, toMode) {
-    var seg = document.getElementById('viewSeg');
-    if (!seg) return 1;
     // Setup isn't a segment, but it leads the toolbar, so treat it as living
     // before the first button — enter from the left, leave to the right.
     if (toMode === 'settings') return -1;
     if (fromMode === 'settings') return 1;
-    var order = [].map.call(seg.querySelectorAll('button'), function(b) { return b.getAttribute('data-view'); });
-    var a = order.indexOf(fromMode), b = order.indexOf(toMode);
-    if (a < 0 || b < 0) return 1;
-    return b >= a ? 1 : -1;
+    return segTravelDirection('viewSeg', 'data-view', fromMode, toMode);
 }
 
-// Slide the freshly-rendered view in from `dir` (1 = from the right).
-function slideViewIn(el, dir) {
-    if (!el) return;
-    el.classList.remove('pk-view-in-right', 'pk-view-in-left');
-    void el.offsetWidth;   // reflow, so re-picking the same class restarts it
-    el.classList.add('pk-view-animating', dir < 0 ? 'pk-view-in-left' : 'pk-view-in-right');
-    var done = function() {
-        el.classList.remove('pk-view-animating', 'pk-view-in-right', 'pk-view-in-left');
-        el.removeEventListener('animationend', done);
-    };
-    el.addEventListener('animationend', done);
-    // animationend never fires under prefers-reduced-motion (animation:none),
-    // so drop the clip guard regardless.
-    setTimeout(done, 400);
-}
-
-// Position a segmented control's sliding thumb under its active button. Pass
-// animate=false to snap without a transition (used on full re-renders). Shared by
-// the player filter (#filterSeg) and the view switcher (#viewSeg).
 // Views that actually read FILTER. Keep in step with renderPlayerRows(),
 // renderMobileCards() and renderTableView() if a new view starts filtering.
 function filterApplies(mode) {
     return mode === 'list' || mode === 'table';
-}
-
-function positionSegThumb(segId, animate) {
-    var seg = document.getElementById(segId);
-    if (!seg) return;
-    // A hidden control measures zero, and writing that would park the thumb at
-    // zero width in the corner for whenever it is shown again.
-    if (!seg.offsetParent) return;
-    var thumb = seg.querySelector('.pk-seg-thumb');
-    var active = seg.querySelector('button.active');
-    if (!thumb || !active) return;
-    if (!animate) {
-        thumb.style.transition = 'none';
-        thumb.style.width = active.offsetWidth + 'px';
-        thumb.style.transform = 'translateX(' + active.offsetLeft + 'px)';
-        void thumb.offsetWidth; // force reflow so the next change can transition
-        thumb.style.transition = '';
-    } else {
-        thumb.style.width = active.offsetWidth + 'px';
-        thumb.style.transform = 'translateX(' + active.offsetLeft + 'px)';
-    }
-}
-
-// Reposition both toolbar sliders (e.g. after a full dashboard re-render or resize).
-function positionAllSegThumbs(animate) {
-    positionSegThumb('filterSeg', animate);
-    positionSegThumb('viewSeg', animate);
 }
 
 function movePlayer(pid, newTable) {
@@ -3691,6 +3742,10 @@ function saveSettings() {
         seats_per_table: parseInt(document.getElementById('cfg_seats_per_table').value || 9),
         auto_assign_tables: (document.getElementById('cfg_auto_assign') || {}).checked ? 1 : 0,
     };
+    // Only sent when the host can actually change it; the server re-checks the
+    // league role regardless and refuses a move it doesn't like.
+    var lgSel = document.getElementById('cfg_league_id');
+    if (lgSel) data.league_id = parseInt(lgSel.value || 0);
     if (document.getElementById('cfg_game_type').value === 'tournament') {
         data.rebuy_amount = Math.max(0, Math.round(parseFloat((document.getElementById('cfg_rebuy') || {}).value || 0))) * 100;
         data.addon_amount = Math.max(0, Math.round(parseFloat((document.getElementById('cfg_addon') || {}).value || 0))) * 100;
@@ -3718,6 +3773,11 @@ function saveSettings() {
         SESSION = j.session;
         POOL = j.pool;
         PAYOUTS = j.payouts || PAYOUTS;
+        // The league may have moved: the jackpot fund and the saved payout
+        // presets are both scoped to it, so pick up the server's view rather
+        // than keep showing the old league's figures.
+        if (j.jackpots) JACKPOTS = j.jackpots;
+        if (typeof j.league_id !== 'undefined') EVENT_LEAGUE_ID = parseInt(j.league_id) || 0;
         if (j.players) PLAYERS = j.players;
         // Save payouts too (tournament only) — all four reward dimensions ride
         // in parallel arrays keyed by row order.
@@ -4223,7 +4283,6 @@ function escHtml(s) {
 loadSession();
 
 // Keep both toolbar sliders aligned if the toolbar reflows on resize.
-window.addEventListener('resize', function() { positionAllSegThumbs(false); });
 
 // Auto-refresh every 10 seconds
 // Pool stats update silently; the roster re-renders whenever the server content

--- a/www/checkin_dl.php
+++ b/www/checkin_dl.php
@@ -457,12 +457,58 @@ if ($action === 'update_config') {
     if ($game_type === 'tournament' && $baked >= $new_buyin && $baked > 0) {
         echo json_encode(['ok' => false, 'error' => 'Baked-in bounty + jackpot must total less than the buy-in (they come out of it).']); exit;
     }
-    if ($jp_amount > 0) {
-        $lgq = $db->prepare('SELECT league_id FROM events WHERE id = ?');
-        $lgq->execute([(int)$s['event_id']]);
-        if (!(int)$lgq->fetchColumn()) {
-            echo json_encode(['ok' => false, 'error' => 'Jackpots are league funds — this event must belong to a league first.']); exit;
+    // League. Editable here so a host can attach the event to a league without
+    // leaving Setup — jackpots are league funds, so hitting "this event must
+    // belong to a league first" used to mean exiting to the event editor and
+    // coming back. Applied BEFORE the jackpot check below, so setting a league
+    // and a jackpot in one save works.
+    $lgq = $db->prepare('SELECT league_id, visibility FROM events WHERE id = ?');
+    $lgq->execute([(int)$s['event_id']]);
+    $evRow0 = $lgq->fetch();
+    $cur_league = (int)($evRow0['league_id'] ?? 0);
+    $event_league = $cur_league;
+
+    if (array_key_exists('league_id', $_POST)) {
+        $want = max(0, (int)$_POST['league_id']);
+        if ($want !== $cur_league) {
+            // Same rule as the event editor: binding an event to a league takes
+            // owner/manager of THAT league (or site admin). Membership alone is
+            // not enough, and unbinding is always allowed to someone who can
+            // already manage the event.
+            $may = true;
+            if ($want > 0) {
+                $role = league_role($want, (int)$current['id']);
+                $may  = $isAdmin || in_array($role, ['owner', 'manager'], true);
+            }
+            if (!$may) {
+                echo json_encode(['ok' => false, 'error' => 'Only an owner or manager of that league can move an event into it.']); exit;
+            }
+            // Jackpot money is held per league. Once this game has banked or paid
+            // any, moving the event would leave that money in the old league's
+            // fund while the game belongs to another — refuse rather than split
+            // the two silently.
+            try {
+                $jq = $db->prepare("SELECT COUNT(*) FROM league_jackpot_log WHERE session_id = ? AND voided = 0");
+                $jq->execute([$session_id]);
+                if ((int)$jq->fetchColumn() > 0) {
+                    echo json_encode(['ok' => false, 'error' => 'This game already has jackpot money in the league fund — that money is held per league, so the league can\'t be changed now.']); exit;
+                }
+            } catch (Exception $e) { /* pre-migration DB: no jackpot log yet */ }
+
+            $db->prepare('UPDATE events SET league_id = ? WHERE id = ?')
+               ->execute([$want ?: null, (int)$s['event_id']]);
+            // "League members only" is meaningless without a league — same
+            // coercion the event editor applies.
+            if (!$want && ($evRow0['visibility'] ?? '') === 'league') {
+                $db->prepare("UPDATE events SET visibility = 'invitees_only' WHERE id = ?")->execute([(int)$s['event_id']]);
+            }
+            db_log_activity((int)$current['id'], "set event id={$s['event_id']} league_id=" . ($want ?: 'none') . " from poker setup");
+            $event_league = $want;
         }
+    }
+
+    if ($jp_amount > 0 && !$event_league) {
+        echo json_encode(['ok' => false, 'error' => 'Jackpots are league funds — this event must belong to a league first.']); exit;
     }
 
     // Satellite target: another upcoming poker event the caller can manage.
@@ -549,11 +595,18 @@ if ($action === 'update_config') {
     ]);
 
     echo json_encode([
-        'ok'      => true,
-        'session' => $srow,
-        'players' => get_players($db, $session_id),
-        'pool'    => calc_pool($db, $session_id),
-        'payouts' => get_payouts($db, $session_id),
+        'ok'        => true,
+        'session'   => $srow,
+        'players'   => get_players($db, $session_id),
+        'pool'      => calc_pool($db, $session_id),
+        'payouts'   => get_payouts($db, $session_id),
+        // The league can change here now, and the jackpot fund and the preset
+        // list are both scoped to it, so hand both back rather than leaving the
+        // page showing the old league's figures.
+        'league_id' => $event_league ?: null,
+        'jackpots'  => ['league_id' => $event_league ?: null,
+                        'balance'     => pk_jackpot_balance($db, $event_league ?: null),
+                        'contributed' => pk_jackpot_contributed($db, $session_id)],
     ]);
     exit;
 }

--- a/www/contact_edit.php
+++ b/www/contact_edit.php
@@ -34,7 +34,7 @@ $canMsg   = $isLinked && (int)$c['linked_user_id'] !== $uid;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Edit Contact &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .ce-wrap { max-width: 560px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .ce-head { display: flex; align-items: center; gap: .6rem; margin-bottom: 1rem; flex-wrap: wrap; }

--- a/www/contacts.php
+++ b/www/contacts.php
@@ -28,7 +28,7 @@ $prefLabels = ['email' => 'Email', 'sms' => 'Text', 'whatsapp' => 'WhatsApp', 'b
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contacts — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .c-wrap { max-width: 1100px; margin: 1.25rem auto; padding: 0 1rem; }
         .c-header { display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem; }

--- a/www/event.php
+++ b/www/event.php
@@ -29,7 +29,7 @@ function ev_show_simple(string $heading, string $body, string $type = 'error'): 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($heading) ?> &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body style="display:flex;align-items:center;justify-content:center;min-height:100vh;padding:1rem">
     <div style="max-width:480px;width:100%;text-align:center">
@@ -182,7 +182,7 @@ if ($token === '' && $page_eid > 0) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($ev['title']) ?> &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .evp-wrap { max-width: 640px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .evp-card { background:#fff; border:1.5px solid #e2e8f0; border-radius:12px; padding:1.5rem; }
@@ -965,7 +965,7 @@ function ev_names_block(string $label, array $names, string $color, array $avata
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?= htmlspecialchars($invite['title']) ?> &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         body { background: var(--bg, #f8fafc); }
         .ev-wrap { min-height:100vh; display:flex; align-items:flex-start; justify-content:center; padding:1.5rem; }

--- a/www/event_edit.php
+++ b/www/event_edit.php
@@ -199,7 +199,7 @@ $pageHeading = $isCopy ? 'Duplicate Event' : ($event ? 'Edit Event' : 'Add Event
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($pageHeading) ?> &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         /* Page frame: the editor fills the viewport below the nav, with the invite
            panes scrolling internally — same layout the 95vh modal provided. */

--- a/www/event_message.php
+++ b/www/event_message.php
@@ -34,7 +34,7 @@ $pretty_time = (!empty($msg['start_time'])) ? date('g:i A', strtotime($msg['star
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex,nofollow">
     <title><?= htmlspecialchars($msg ? $msg['subject'] : 'Message') ?> — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>

--- a/www/event_polls.php
+++ b/www/event_polls.php
@@ -148,7 +148,7 @@ $backUrl   = '/calendar.php?m=' . urlencode(substr($event['start_date'], 0, 7)) 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Polls &mdash; <?= htmlspecialchars($event['title']) ?> &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .pl-wrap { max-width: 860px; margin: 1.5rem auto; padding: 0 1rem; }
         .pl-card { background:#fff; border:1.5px solid #e2e8f0; border-radius:10px; padding:1.25rem; margin-bottom:1.25rem; }

--- a/www/forgot_password.php
+++ b/www/forgot_password.php
@@ -80,7 +80,7 @@ $token = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>

--- a/www/help-guests.php
+++ b/www/help-guests.php
@@ -12,7 +12,7 @@ $allow_reg   = get_setting('allow_registration', '1') === '1';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Guest Guide &mdash; <?= htmlspecialchars($site_name) ?></title>
     <?php render_seo_meta('Guest Guide', 'Got an invite to a game night? How to RSVP in one click and check in at the door, no account required.', 'help-guests.php'); ?>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .help-wrap { max-width: 760px; margin: 2rem auto 4rem; padding: 0 1.5rem; }
         .help-wrap h1 { font-size: 2rem; margin-bottom: .5rem; }

--- a/www/help-hosts.php
+++ b/www/help-hosts.php
@@ -12,7 +12,7 @@ $allow_reg   = get_setting('allow_registration', '1') === '1';
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Host Guide &mdash; <?= htmlspecialchars($site_name) ?></title>
     <?php render_seo_meta('Host Guide', 'Step-by-step guide to hosting a game night: set up a league, invite guests, adjust event settings, track RSVPs, and run the tournament timer.', 'help-hosts.php'); ?>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .help-wrap { max-width: 760px; margin: 2rem auto 4rem; padding: 0 1.5rem; }
         .help-wrap h1 { font-size: 2rem; margin-bottom: .5rem; }

--- a/www/index.php
+++ b/www/index.php
@@ -101,7 +101,7 @@ $tlMonths = $tlStmt->fetchAll();
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
     <?php render_seo_meta($site_name, 'Plan game nights and poker tournaments: invite friends by email, SMS, or WhatsApp, track RSVPs, run a tournament clock, and check players in at the door.', ''); ?>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         /* ── Main layout: centered content, sidebar pinned to viewport left ── */
         .page-layout {

--- a/www/join_league.php
+++ b/www/join_league.php
@@ -124,7 +124,7 @@ function render_page(string $site, string $title, string $body_html, string $act
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($title) ?> — <?= htmlspecialchars($site) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .jl-wrap { max-width: 520px; margin: 3rem auto; padding: 0 1rem; }
         .jl-card { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 10px; padding: 1.75rem; text-align: center; }

--- a/www/league.php
+++ b/www/league.php
@@ -477,7 +477,7 @@ function ordinal($n) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($league['name']) ?> — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .lg-wrap { max-width: 960px; margin: 1.5rem auto; padding: 0 1rem; }
         .lg-head { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 10px; padding: 1.2rem; margin-bottom: 1rem; }

--- a/www/league_edit.php
+++ b/www/league_edit.php
@@ -33,7 +33,7 @@ $vals = $league ?: [
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= $isEdit ? 'Edit' : 'Create' ?> League — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .le-wrap { max-width: 560px; margin: 1.5rem auto; padding: 0 1rem; }
         .le-card { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 10px; padding: 1.25rem; }

--- a/www/league_invite.php
+++ b/www/league_invite.php
@@ -68,7 +68,7 @@ if (!$row) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Invitation — <?= htmlspecialchars($site) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .li-wrap { max-width: 520px; margin: 3rem auto; padding: 0 1rem; }
         .li-card { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 10px; padding: 1.5rem; text-align: center; }

--- a/www/league_player.php
+++ b/www/league_player.php
@@ -146,7 +146,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($player_name) ?> &ndash; <?= htmlspecialchars($league['name']) ?> stats &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .lp-wrap { max-width: 760px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .lp-card { background:#fff; border:1.5px solid #e2e8f0; border-radius:12px; padding:1.5rem; }

--- a/www/league_public.php
+++ b/www/league_public.php
@@ -48,7 +48,7 @@ if ($slug === '') {
     <meta property="og:description" content="Browse the leagues on <?= htmlspecialchars($site_name) ?> and see their upcoming events.">
     <meta property="og:url" content="<?= htmlspecialchars($dirUrl) ?>">
     <meta name="description" content="Browse the leagues on <?= htmlspecialchars($site_name) ?> and see their upcoming events.">
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .ld-layout { max-width: 860px; margin: 0 auto; padding: 0 1.25rem 3rem; }
         .ld-head { margin: 1.75rem 0 .35rem; font-size: 1.8rem; font-weight: 800; color: #0f172a; }
@@ -144,7 +144,7 @@ if (!$league) {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="robots" content="noindex,nofollow">
         <title>League Not Found &mdash; <?= htmlspecialchars($site_name) ?></title>
-        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     </head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;padding:1rem">
         <div style="max-width:480px;width:100%;text-align:center">
             <div style="background:#fef2f2;border:2px solid #dc2626;border-radius:12px;padding:2rem 1.5rem;margin-bottom:1.5rem">
@@ -284,7 +284,7 @@ $autoJoin = $user && $myRole === null && !$pending && ($_GET['join'] ?? '') === 
     <meta name="twitter:card" content="summary">
     <?php endif; ?>
     <meta name="description" content="<?= htmlspecialchars($ogDesc) ?>">
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .lp-layout { max-width: 860px; margin: 0 auto; padding: 0 1.25rem 3rem; }
         .lp-hero { margin: 1.5rem 0 0; border-radius: 12px; overflow: hidden; border: 1px solid #e2e8f0; background: #f1f5f9; }

--- a/www/leagues.php
+++ b/www/leagues.php
@@ -51,7 +51,7 @@ $csrf = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Leagues — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .lg-wrap { max-width: 960px; margin: 1.5rem auto; padding: 0 1rem; }
         .lg-header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 1rem; gap: 1rem; flex-wrap: wrap; }

--- a/www/login.php
+++ b/www/login.php
@@ -170,7 +170,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/message_thread.php
+++ b/www/message_thread.php
@@ -115,7 +115,7 @@ $lastId = $messages ? (int)end($messages)['id'] : 0;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($title) ?> &ndash; Messages &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .dt-wrap { max-width: 680px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .dt-head { display:flex; align-items:center; gap:.6rem; margin-bottom:.35rem; flex-wrap:wrap; }

--- a/www/messages.php
+++ b/www/messages.php
@@ -64,7 +64,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Messages &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .dm-wrap { max-width: 680px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .dm-row { display:block; background:#fff; border:1.5px solid #e2e8f0; border-radius:10px; padding:.7rem .9rem; margin-bottom:.5rem; text-decoration:none; color:inherit; }

--- a/www/mfa_challenge.php
+++ b/www/mfa_challenge.php
@@ -126,7 +126,7 @@ $token = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Two-Factor Verification — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/mfa_setup.php
+++ b/www/mfa_setup.php
@@ -134,7 +134,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Two-Factor Setup — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/my_events.php
+++ b/www/my_events.php
@@ -106,7 +106,7 @@ function rsvp_badge(?string $rsvp, ?string $approval_status = 'approved'): strin
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Events — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         @media (max-width: 1024px) {
             .me-view-btn { min-height:44px !important;font-size:.9rem !important;padding:.5rem .85rem !important;display:inline-flex;align-items:center; }

--- a/www/notifications.php
+++ b/www/notifications.php
@@ -44,7 +44,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Notifications &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .nf-wrap { max-width: 680px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .nf-row { display:block; background:#fff; border:1.5px solid #e2e8f0; border-radius:10px; padding:.7rem .9rem; margin-bottom:.5rem; text-decoration:none; color:inherit; }

--- a/www/pk-seg.js
+++ b/www/pk-seg.js
@@ -1,0 +1,93 @@
+/* pk-seg.js — the segmented control + slide-in engine.
+ *
+ * The house switcher: when a user picks between sibling views, panes or
+ * filters, use a .pk-seg pill with a sliding thumb and slide the new content
+ * in from the side the thumb travelled. Prefer this over tab strips, underlined
+ * tabs, radio groups or plain button rows. Styles live in style.css so any page
+ * gets them; this file is loaded by _footer.php, so any page gets the behaviour.
+ *
+ *   positionSegThumb(segId, animate)          move the thumb to the active button
+ *   positionAllSegThumbs(animate)             re-measure every .pk-seg on the page
+ *   segTravelDirection(segId, attr, from, to) 1 = travelled right, -1 = left
+ *   slideViewIn(el, dir)                      slide freshly-shown content in
+ *
+ * Markup contract:
+ *   <div class="pk-seg" id="mySeg">
+ *     <span class="pk-seg-thumb"></span>
+ *     <button data-x="a" class="active">A</button>
+ *     <button data-x="b">B</button>
+ *   </div>
+ *
+ * Loaded WITHOUT defer: pages that put their own inline <script> after the
+ * footer (checkin.php does) must see these defined already.
+ */
+(function () {
+    'use strict';
+
+    // Move a control's thumb under its active button. animate=false snaps
+    // without a transition — use it on a fresh render, where nothing moved;
+    // animate=true for a user's click, where the movement is the point.
+    window.positionSegThumb = function (segId, animate) {
+        var seg = document.getElementById(segId);
+        if (!seg) return;
+        // A hidden control measures zero, and writing that would park the thumb
+        // at zero width in the corner for whenever it is shown again. Position
+        // AFTER a control becomes visible, never before.
+        if (!seg.offsetParent) return;
+        var thumb = seg.querySelector('.pk-seg-thumb');
+        var active = seg.querySelector('button.active');
+        if (!thumb || !active) return;
+        if (!animate) {
+            thumb.style.transition = 'none';
+            thumb.style.width = active.offsetWidth + 'px';
+            thumb.style.transform = 'translateX(' + active.offsetLeft + 'px)';
+            void thumb.offsetWidth;   // reflow so the next change can transition
+            thumb.style.transition = '';
+        } else {
+            thumb.style.width = active.offsetWidth + 'px';
+            thumb.style.transform = 'translateX(' + active.offsetLeft + 'px)';
+        }
+    };
+
+    // Re-measure every control on the page. Needed after a full re-render or a
+    // resize, and any time a segment is shown, hidden, enabled or disabled —
+    // those change the buttons' widths even when the selection has not changed.
+    window.positionAllSegThumbs = function (animate) {
+        var segs = document.querySelectorAll('.pk-seg[id]');
+        for (var i = 0; i < segs.length; i++) positionSegThumb(segs[i].id, animate);
+    };
+
+    // Which way the thumb travels between two values, so content can enter from
+    // the same side. Reads the LIVE button order rather than a hardcoded list,
+    // so it stays correct when a segment is conditionally absent.
+    window.segTravelDirection = function (segId, attr, from, to) {
+        var seg = document.getElementById(segId);
+        if (!seg) return 1;
+        var order = [].map.call(seg.querySelectorAll('button'), function (b) {
+            return b.getAttribute(attr);
+        });
+        var a = order.indexOf(from), b = order.indexOf(to);
+        if (a < 0 || b < 0) return 1;
+        return b >= a ? 1 : -1;
+    };
+
+    // Slide freshly-shown content in from `dir` (1 = from the right).
+    window.slideViewIn = function (el, dir) {
+        if (!el) return;
+        el.classList.remove('pk-view-in-right', 'pk-view-in-left');
+        void el.offsetWidth;   // reflow, so re-picking the same class restarts it
+        el.classList.add('pk-view-animating', dir < 0 ? 'pk-view-in-left' : 'pk-view-in-right');
+        var done = function () {
+            el.classList.remove('pk-view-animating', 'pk-view-in-right', 'pk-view-in-left');
+            el.removeEventListener('animationend', done);
+        };
+        el.addEventListener('animationend', done);
+        // animationend never fires under prefers-reduced-motion (animation:none),
+        // so drop the clip guard on a timer regardless.
+        setTimeout(done, 400);
+    };
+
+    // A resize changes button widths, so every control needs re-measuring. Free
+    // for any page that uses the control — no per-page wiring.
+    window.addEventListener('resize', function () { positionAllSegThumbs(false); });
+})();

--- a/www/poll.php
+++ b/www/poll.php
@@ -72,7 +72,7 @@ if (!$recipient || !$poll || !$event || empty($poll['questions'])) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Poll &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         body { background:#f1f5f9; }
         .po-wrap { max-width: 560px; margin: 2rem auto; padding: 0 1rem; }

--- a/www/post_public.php
+++ b/www/post_public.php
@@ -48,7 +48,7 @@ if (!$post || (int)($post['hidden'] ?? 0) === 1 || (int)($post['league_id'] ?? 0
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="robots" content="noindex,nofollow">
         <title>Link Not Found — <?= htmlspecialchars($site_name) ?></title>
-        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     </head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;padding:1rem">
         <div style="max-width:480px;width:100%;text-align:center">
             <div style="background:#fef2f2;border:2px solid #dc2626;border-radius:12px;padding:2rem 1.5rem;margin-bottom:1.5rem">
@@ -85,7 +85,7 @@ $redir = '/post_public.php?token=' . urlencode($token);
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex,nofollow">
     <title><?= htmlspecialchars($post['title']) ?> — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .page-layout { max-width: 740px; margin: 2rem auto 0; padding: 0 1.5rem; }
         .post-card { background:#fff; border:1px solid #e2e8f0; border-radius:12px; padding:1.75rem; margin-bottom:1.5rem; }

--- a/www/privacy.php
+++ b/www/privacy.php
@@ -8,7 +8,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <?php $nav_active = ''; require __DIR__ . '/_nav.php'; ?>

--- a/www/register.php
+++ b/www/register.php
@@ -18,7 +18,7 @@ if (get_setting('allow_registration', '1') !== '1') {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title><?= htmlspecialchars($site_name) ?></title>
-        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     </head>
     <body>
     <?php $nav_active = ''; require __DIR__ . '/_nav.php'; ?>
@@ -142,7 +142,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/register_dl.php
+++ b/www/register_dl.php
@@ -18,7 +18,7 @@ if (get_setting('allow_registration', '1') !== '1') {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title><?= htmlspecialchars($site_name) ?></title>
-        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+        <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     </head>
     <body>
     <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>
@@ -87,7 +87,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/resend_verification.php
+++ b/www/resend_verification.php
@@ -58,7 +58,7 @@ $prefill = htmlspecialchars($_GET['email'] ?? $_GET['phone'] ?? $_POST['identifi
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>

--- a/www/reset_password.php
+++ b/www/reset_password.php
@@ -70,7 +70,7 @@ $token = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>

--- a/www/rsvp.php
+++ b/www/rsvp.php
@@ -190,7 +190,7 @@ function show_page(string $title, string $body, string $type): void {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($title) ?> — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body style="display:flex;align-items:center;justify-content:center;min-height:100vh;padding:1rem">
     <div style="max-width:480px;width:100%;text-align:center">

--- a/www/settings.php
+++ b/www/settings.php
@@ -238,7 +238,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .settings-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
         @media (max-width: 640px) { .settings-grid { grid-template-columns: 1fr; } }

--- a/www/sms_conversations.php
+++ b/www/sms_conversations.php
@@ -103,7 +103,7 @@ if ($mode === 'thread') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conversations — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .conv-wrap { max-width:820px; margin:1.5rem auto; padding:0 1rem; }
         .conv-header { display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:.75rem; margin-bottom:1rem; }

--- a/www/sms_log.php
+++ b/www/sms_log.php
@@ -82,7 +82,7 @@ unset($_SESSION['flash']);
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Notification Log — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .sms-log-wrap { max-width:1200px; margin:1.5rem auto; padding:0 1rem; }
         .sms-log-header { display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:.75rem; margin-bottom:1rem; }

--- a/www/style.css
+++ b/www/style.css
@@ -740,3 +740,34 @@ footer { text-align: center; padding: 2.5rem 1rem; color: var(--muted); font-siz
 /* ── Shared circular avatar (photo, or deterministic colored initial) ── */
 .gn-avatar{display:inline-flex;align-items:center;justify-content:center;border-radius:50%;color:#fff;font-weight:700;line-height:1;text-transform:uppercase;flex-shrink:0;vertical-align:middle;overflow:hidden;box-sizing:border-box}
 img.gn-avatar{object-fit:cover;background:transparent}
+
+/* ── Segmented control + slide-in (see pk-seg.js and CLAUDE.md) ──────────────
+   The house switcher for picking between sibling views, panes or filters:
+   a pill track with a thumb that slides under the active button, and content
+   that enters from the side the thumb travelled. Prefer this over tab strips,
+   underlined tabs, radio groups or plain button rows.
+
+   Timings are shared on purpose — thumb .2s, content .32s, both on the same
+   easing curve. Don't introduce new durations for the same gesture. */
+.pk-seg{position:relative;display:inline-flex;border:1.5px solid #cbd5e1;border-radius:8px;background:#dde3ec;padding:3px;box-shadow:inset 0 1px 2px rgba(15,23,42,.14)}
+.pk-seg-thumb{position:absolute;top:3px;bottom:3px;left:0;width:0;border-radius:6px;background:var(--accent,#2563eb);box-shadow:0 1px 3px rgba(37,99,235,.5);z-index:0;transition:transform .2s cubic-bezier(.4,0,.2,1),width .2s cubic-bezier(.4,0,.2,1)}
+.pk-seg button{position:relative;z-index:1;border:none;background:transparent;cursor:pointer;padding:.34rem .75rem;font-size:.76rem;font-weight:600;color:#475569;white-space:nowrap;transition:color .15s}
+.pk-seg button:hover:not(.active){color:#1e293b}
+.pk-seg button.active{color:#fff}
+/* For when the selection lives outside the control, so no segment is current —
+   parking the thumb under a stale button would look like two things selected. */
+.pk-seg.thumb-off .pk-seg-thumb{opacity:0}
+
+/* Content entry. Only the INCOMING element animates: cross-fading the outgoing
+   one too would need both stacked, doubling page height mid-swap. */
+@keyframes pkViewInRight{from{opacity:0;transform:translateX(26px)}to{opacity:1;transform:none}}
+@keyframes pkViewInLeft{from{opacity:0;transform:translateX(-26px)}to{opacity:1;transform:none}}
+.pk-view-in-right{animation:pkViewInRight .32s cubic-bezier(.4,0,.2,1)}
+.pk-view-in-left{animation:pkViewInLeft .32s cubic-bezier(.4,0,.2,1)}
+/* `clip` rather than `hidden`: it doesn't create a scroll container, so the
+   26px offset can't flash a horizontal scrollbar. Removed when the animation
+   ends so content keeps any horizontal scrolling of its own. */
+.pk-view-animating{overflow-x:clip}
+@media(prefers-reduced-motion:reduce){
+    .pk-view-in-right,.pk-view-in-left{animation:none}
+}

--- a/www/support.php
+++ b/www/support.php
@@ -28,7 +28,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Support &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .sp-wrap { max-width: 680px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .sp-card { background: #fff; border: 1.5px solid #e2e8f0; border-radius: 12px; padding: 1rem 1.15rem; margin-bottom: 1.1rem; }

--- a/www/support_ticket.php
+++ b/www/support_ticket.php
@@ -44,7 +44,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ticket #<?= (int)$ticket['id'] ?> &ndash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .st-wrap { max-width: 680px; margin: 1.25rem auto 2rem; padding: 0 1rem; }
         .st-head { display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; margin-bottom: .35rem; }

--- a/www/terms.php
+++ b/www/terms.php
@@ -8,7 +8,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Terms &amp; Conditions &mdash; <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <?php $nav_active = ''; require __DIR__ . '/_nav.php'; ?>

--- a/www/timer.php
+++ b/www/timer.php
@@ -88,7 +88,7 @@ if (isset($_GET['view']) && $_GET['view'] === 'remote' && !empty($_GET['key'])) 
     $ts->execute([$remote_key]);
     $timer = $ts->fetch();
     if (!$timer) {
-        echo '<!DOCTYPE html><html><head><title>Invalid Link</title><link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>"></head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0f172a;color:#fff"><div class="card" style="text-align:center"><h2>Invalid Timer Link</h2><p>This timer link is no longer valid.</p></div></body></html>';
+        echo '<!DOCTYPE html><html><head><title>Invalid Link</title><link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>"></head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0f172a;color:#fff"><div class="card" style="text-align:center"><h2>Invalid Timer Link</h2><p>This timer link is no longer valid.</p></div></body></html>';
         exit;
     }
 
@@ -275,7 +275,7 @@ $themeCss   = timer_theme_css_vars($themeProps);
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Poker Timer &mdash; <?= htmlspecialchars($site_name) ?></title>
     <link rel="icon" href="/favicon.php">
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <link rel="stylesheet" href="/vendor/fonts/fonts.css">
     <script>window.TIMER_THEME = <?= json_encode($themeProps, JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>; window.TIMER_THEME_ID = <?= $themeId ? (int)$themeId : 'null' ?>;</script>
     <style id="themeStyle"><?= $themeCss ?></style>

--- a/www/user_edit.php
+++ b/www/user_edit.php
@@ -150,7 +150,7 @@ $site_name = get_setting('site_name', 'Game Night');
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         .edit-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
         @media (max-width: 640px) { .edit-grid { grid-template-columns: 1fr; } }

--- a/www/verify_email.php
+++ b/www/verify_email.php
@@ -47,7 +47,7 @@ if ($token_hash === '') {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 <nav><div class="nav-top"><a class="brand" href="/"><?= htmlspecialchars($site_name) ?></a></div></nav>

--- a/www/verify_phone.php
+++ b/www/verify_phone.php
@@ -46,7 +46,7 @@ $token = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Verify Account — <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
 </head>
 <body>
 

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2063');
+define('APP_VERSION', '0.2064');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and

--- a/www/walkin.php
+++ b/www/walkin.php
@@ -327,7 +327,7 @@ $csrf_token = csrf_token();
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Register for Event – <?= htmlspecialchars($site_name) ?></title>
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         body { background: var(--bg, #f8fafc); }
         .walkin-wrap {

--- a/www/walkin_display.php
+++ b/www/walkin_display.php
@@ -60,7 +60,7 @@ if (!empty($event['start_time'])) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Registration QR &mdash; <?= htmlspecialchars($event['title']) ?></title>
     <link rel="icon" href="/favicon.php">
-    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION) ?>">
+    <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <style>
         html { height: 100%; }
         body {


### PR DESCRIPTION
### Added — the event's league is editable from Game Setup

Jackpot funds and saved payout presets both belong to a league, so configuring a jackpot on an event with no league hit *"Jackpots are league funds — this event must belong to a league first"* and the only way forward was to leave Setup, edit the event, and come back.

A **League** field now sits left of Game Type and saves with everything else. It rides the normal Save rather than applying on change — applying immediately would discard other unsaved edits in the pane when it re-rendered. Server-side it is applied **before** the jackpot validation, which is what makes the fix work: a league and a jackpot can be set in one save.

Authorization mirrors `_event_save.php` exactly: binding an event to a league takes **owner or manager of that league, or site admin**. Membership alone is not enough. The event's current league is always listed, marked, even for a co-host with no role on it.

One guard that wasn't requested but the money required: **a game that has already banked or paid jackpot money cannot change league.** That money sits in one league's fund, so moving the event would leave the cash in one league and the game in another.

| Case | Result |
|---|---|
| Jackpot with no league (the old dead end) | refused |
| **League + jackpot in one save** | **succeeds** |
| Non-admin manager of L27 → move to L17 | refused, and L17 never offered in their picker |
| Non-admin manager → keep L27, or unbind to None | allowed |
| Move while jackpot money is banked | refused, event untouched |

### Changed — the segmented control becomes shared, and Setup uses it

Setup's tabs are now the sliding segmented control that the toolbar's view and filter strips use, with the pane sliding in from the side the thumb travelled. An underlined-tab strip was a third idiom for the same gesture. Disabled tabs (a cash game has no payout structure) are dimmed and don't light up on hover, and the thumb is re-measured whenever a segment is shown, hidden, enabled or disabled — widths move even when the selection doesn't.

The control then moved **out of `checkin.php`**: styles to `style.css`, behaviour to a new `pk-seg.js` that `_footer.php` loads on every page. Documenting a house style whose implementation was trapped in one page was a real inconsistency. `positionAllSegThumbs()` now scans every `.pk-seg[id]` instead of three hardcoded ids, and the `resize` re-measure moved into the shared file so no page has to wire it.

`pk-seg.js` is deliberately **not deferred**: a page may put its own inline `<script>` after the footer (`checkin.php` does) and must see the functions already defined.

Documented in CLAUDE.md as the preferred switcher, with the rules that keep it from breaking — content enters from the side the thumb travelled, re-measure on width changes not just selection changes, a hidden control measures zero, don't replay on a no-op, and reduced motion is handled centrally. `_admin_tabs.php` is explicitly excluded: those tabs are links to separate *pages*, not an in-page switcher.

The **"this game isn't set up yet"** prompt is amber rather than blue — in the informational palette it read as a tip and disappeared into the page.

### Fixed

**The Game Preset bar was unreachable on a cash game.** It was rendered only when the *saved* game type was tournament, and `previewGameType()` didn't touch it — so choosing Tournament revealed the tournament fields and the Payouts tab but not the presets, which stayed out of reach until the game type was saved and the editor reopened. The same defect the Payouts tab had in v0.2060. It's now always rendered and hidden by game type, with the preset list populated for both types so a revealed select isn't empty.

**Loading a preset threw away an unsaved game-type choice.** `loadPayoutStructure()` redraws via `renderDashboard()` then `refreshSettingsView()`, both rebuilding the pane from the saved session — so picking Tournament on a game still saved as cash and then loading a preset snapped the dropdown back to Cash and hid everything that choice had revealed, including the preset bar just used. This is what was reported. The pending choice is captured before the redraw and re-applied after; the first attempt guarded only `refreshSettingsView()` and still failed, because `renderDashboard()` runs first and had already reset the dropdown.

Verified on the reported fixture:

| Step | saved | dropdown | preset bar |
|---|---|---|---|
| Cash session, Setup open | cash | cash | hidden |
| Pick Tournament | cash | tournament | **visible** |
| **Load preset** | cash | **tournament** | **still visible** |
| Save, reopen | tournament | tournament | visible |

**Stylesheet edits between releases served stale CSS.** `style.css` was cache-busted on `APP_VERSION` alone, so any change between version bumps kept browsers on their cached copy. It now carries the file's mtime as well — the guard `pk-dialogs.js` already had — across all 54 pages that link it. This surfaced when the shared rules moved out of a page's inline `<style>`: the rules were gone from the page and not yet in the cached stylesheet, so the control lost its styling and animation entirely. Verified by sampling the thumb mid-transition (90ms into a 200ms move it sits between the two positions, not snapped) rather than only checking the CSS is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)