### PR TITLE
Fix fatal parse error that made the timer a white page (v0.2066)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2066] - 2026-08-08
+
+### Fixed
+- **The timer was a white page on every request.** `www/timer.php` had a fatal parse error, so Apache returned a 500 with an empty body for every hit, including from the check-in console's Timer button. The cause was the v0.2064 stylesheet cache-buster sweep: it rewrote the `style.css` link on all 54 pages that carry one, and in `timer.php` one of those links lives inside a PHP string rather than in template output, in the invalid-remote-link branch at line 91. A short-echo tag is not evaluated inside a string literal, and its quotes terminated the string, which made the whole file unparseable and took down every code path in it, not just that branch. The markup is now concatenated. Note this shipped in v0.2064 and was live from that deploy until now; the file has been unparseable that whole time, which is why the timer failed rather than degraded. A `php -l` sweep across `www/*.php` catches this class of breakage in seconds and is worth running before any push that touches many files at once; the other 53 pages were checked this way and are clean.
+
 ## [v0.2065] - 2026-08-08
 
 ### Fixed

--- a/www/timer.php
+++ b/www/timer.php
@@ -88,7 +88,13 @@ if (isset($_GET['view']) && $_GET['view'] === 'remote' && !empty($_GET['key'])) 
     $ts->execute([$remote_key]);
     $timer = $ts->fetch();
     if (!$timer) {
-        echo '<!DOCTYPE html><html><head><title>Invalid Link</title><link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>"></head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0f172a;color:#fff"><div class="card" style="text-align:center"><h2>Invalid Timer Link</h2><p>This timer link is no longer valid.</p></div></body></html>';
+        // This markup is a PHP string, not template output, so the cache-buster
+        // has to be concatenated. A short-echo tag here is never evaluated, and
+        // its quotes close the string, which made the whole file unparseable.
+        // (Do not name the closing tag in a comment either: it ends PHP mode.)
+        echo '<!DOCTYPE html><html><head><title>Invalid Link</title><link rel="stylesheet" href="/style.css?v='
+           . htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0))
+           . '"></head><body style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0f172a;color:#fff"><div class="card" style="text-align:center"><h2>Invalid Timer Link</h2><p>This timer link is no longer valid.</p></div></body></html>';
         exit;
     }
 

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2065');
+define('APP_VERSION', '0.2066');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Fixed

**The timer was a white page on every request.** `www/timer.php` had a fatal parse error, so Apache returned a 500 with an empty body for every hit, including from the check-in console's Timer button.

The cause was the v0.2064 stylesheet cache-buster sweep. It rewrote the `style.css` link on all 54 pages that carry one, and in `timer.php` one of those links lives inside a PHP string rather than in template output, in the invalid-remote-link branch at line 91. A short-echo tag is not evaluated inside a string literal, and its quotes terminated the string, which made the whole file unparseable and took down every code path in it, not just that branch. The markup is now concatenated.

This shipped in v0.2064 and was live from that deploy until now, so the timer was down for the entire window rather than degraded.

### Verification

`php -l` on all of `www/*.php` in the container: clean, `timer.php` included. The previously broken branch was exercised directly on dev with `?view=remote&key=bogus123` and now returns 200 with a correctly interpolated cache-buster (`style.css?v=0.2065.1786218742`), and the normal timer page returns 200.

A `php -l` sweep across `www/*.php` catches this class of breakage in seconds and is worth running before any push that touches many files at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)