### PR TITLE
Blinds show the whole amount with separators, not 2K/2.5K (v0.2067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2067] - 2026-08-08
+
+### Changed
+- **Blinds show the whole amount with thousand separators, not an abbreviation.** The timer rendered 2000 as `2K` and 2500 as `2.5K`, and at a glance across a room `2.5K` and `25K` differ by a single glyph, which is a bad trade for the width it saved on the one number everyone at the table is reading. `fmtChips()` in `www/timer.php` now returns `2,000` and `2,500`, and `100,000` once the levels get deep. The grouping is pinned to `en-US` rather than the visitor's locale: a timer on a TV is a shared display, and a browser set to a European locale would render `2.000`, which reads as two at that font size. Fractional blinds for home stakes keep their two decimals with no float dust, the behaviour added in v0.2035, and values under a thousand are unchanged. The function is used only for the current and next level's blinds and antes, so nothing else in the timer moved. Note the standalone tournament-timer fork carries its own copy of this function and does not inherit the change.
+
 ## [v0.2066] - 2026-08-08
 
 ### Fixed

--- a/www/timer.php
+++ b/www/timer.php
@@ -1954,12 +1954,17 @@ function linkTimerToEvent() {
     window.location.href = '/timer.php?event_id=' + encodeURIComponent(sel.value);
 }
 function fmtChips(n) {
-    if (n >= 1000000) return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
-    // Abbreviate only when exact at one decimal (1200 → 1.2K); otherwise show in full (1250 stays 1250).
-    if (n >= 1000 && n % 100 === 0) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
-    if (n >= 1000) return String(n);
-    // Fractional blinds (.25/.50 home stakes): show up to 2 decimals, no float dust.
-    return (n % 1 === 0) ? String(n) : n.toFixed(2);
+    // Blinds show the literal amount, grouped: 2,000 never 2K, 2,500 never 2.5K.
+    // This is read from across the room, where an abbreviation costs more than
+    // the width it saves — 2.5K and 25K differ by one glyph at a glance — and
+    // the grouping is what keeps 100,000 legible once the levels get deep.
+    // Fractional blinds (.25/.50 home stakes): up to 2 decimals, no float dust.
+    // en-US is pinned rather than using the visitor's locale: a timer on a TV
+    // is a shared display, and a browser set to de-DE would render 2.000, which
+    // reads as two at this font size.
+    return (n % 1 === 0)
+        ? n.toLocaleString('en-US')
+        : n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 // ─── §7.2.1  Get current level data ──────────────────────────────

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2066');
+define('APP_VERSION', '0.2067');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Changed

**Blinds show the whole amount with thousand separators, not an abbreviation.** The timer rendered 2000 as `2K` and 2500 as `2.5K`. At a glance across a room, `2.5K` and `25K` differ by a single glyph, which is a bad trade for the width it saved on the one number everyone at the table is reading.

`fmtChips()` in `www/timer.php` now returns `2,000` and `2,500`, and `100,000` once the levels get deep. The grouping is pinned to `en-US` rather than following the visitor's locale: a timer on a TV is a shared display, and a browser set to a European locale would render `2.000`, which reads as two at that font size.

Fractional blinds for home stakes keep their two decimals with no float dust, the behaviour added in v0.2035, and values under a thousand are unchanged. The function is used only for the current and next level's blinds and antes, so nothing else in the timer moved.

Note the standalone tournament-timer fork carries its own copy of this function and does not inherit the change.

### Verification

Exercised `fmtChips()` directly in the browser on dev across representative values:

| Input | Output |
|---|---|
| 500 | 500 |
| 1000 | 1,000 |
| 2500 | 2,500 |
| 25000 | 25,000 |
| 100000 | 100,000 |
| 1000000 | 1,000,000 |
| 0.25 / 0.5 / 1.5 | 0.25 / 0.50 / 1.50 |

Full recursive `php -l` sweep across all 128 PHP files in the container: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)