### PR TITLE
Cast display's blinds match the timer's, not 2K/2.5K (v0.2068)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2068] - 2026-08-08
+
+### Changed
+- **The cast display's blinds match the timer's.** v0.2067 stopped abbreviating blinds in `www/timer.php`, but `www/cast_receiver.php` carries its own `fmtChips()` and kept rendering `2K` and `2.5K` — on the screen furthest from the reader, where the abbreviation is least defensible. Its copy now formats identically: the whole amount with `en-US` thousand separators, two decimals preserved for fractional home stakes. Those are the only two chip formatters in the tree; a grep for the abbreviating pattern across `www/` returns nothing else. Worth remembering that the timer has two display surfaces and a change to one is not a change to both.
+
 ## [v0.2067] - 2026-08-08
 
 ### Changed

--- a/www/cast_receiver.php
+++ b/www/cast_receiver.php
@@ -144,10 +144,15 @@
     }
 
     function fmtChips(v) {
-        if (v >= 1000000) return (v / 1000000) + 'M';
-        if (v >= 1000) return (v / 1000) + 'K';
+        // Kept in step with fmtChips() in timer.php: the literal amount, grouped,
+        // never 2K or 2.5K. This is the cast display, so the case against
+        // abbreviating is stronger here than anywhere — it is furthest from the
+        // reader. en-US is pinned so a browser locale that groups with dots
+        // cannot render 2.000, which reads as two across a room.
         // Fractional blinds (.25/.50 home stakes): up to 2 decimals, no float dust.
-        return (v % 1 === 0) ? String(v) : v.toFixed(2);
+        return (v % 1 === 0)
+            ? v.toLocaleString('en-US')
+            : v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
     }
 
     function fmtTime(sec) {

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2067');
+define('APP_VERSION', '0.2068');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Changed

**The cast display's blinds match the timer's.** v0.2067 stopped abbreviating blinds in `www/timer.php`, but `www/cast_receiver.php` carries its own `fmtChips()` and kept rendering `2K` and `2.5K`, on the screen furthest from the reader, where the abbreviation is least defensible.

Its copy now formats identically: the whole amount with `en-US` thousand separators, two decimals preserved for fractional home stakes. Those are the only two chip formatters in the tree; a grep for the abbreviating pattern across `www/` returns nothing else.

Worth remembering that the timer has two display surfaces and a change to one is not a change to both. That is how v0.2067 shipped incomplete.

### Verification

`fmtChips()` exercised directly in the browser on the dev cast receiver: `500 → 500`, `1000 → 1,000`, `2500 → 2,500`, `25000 → 25,000`, `100000 → 100,000`, `1000000 → 1,000,000`, `0.25 → 0.25`, `0.5 → 0.50`. Identical to timer.php's output for the same inputs. Full recursive `php -l` sweep across the container: clean. `cast_receiver.php` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)