### PR TITLE
Security: authorization, sanitization and escaping hardening (v0.2070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2070] - 2026-08-09
+
+### Security
+- **Event authorization now hangs off an account id rather than a username string.** `event_invites` gains a `user_id` column, backfilled once from the existing username match, and both `can_manage_event()` and `event_visibility_sql()` join on it. An invite row that does not correspond to a real account no longer confers visibility or co-host authority. Verified access-preserving before shipping: every existing (user, event, role) pair was compared under the old and new logic, with none lost and none gained. Note the deliberate behaviour change: an invite typed as a plain name no longer starts granting access if someone later registers under that name, so a host who wants a real co-host adds them once they have an account.
+- **Hardened HTML sanitization.** `sanitize_html()` did not descend into elements it was about to unwrap, so their contents were emitted without the tag allowlist, attribute stripping or URL scheme checks being applied. It now sanitizes those subtrees before unwrapping. Allowed formatting, lists, links and whitelisted embeds are unaffected.
+- **Corrected escaping in admin confirmation dialogs.** Five `onsubmit` handlers across `user_edit.php`, `admin_settings.php` and `admin_settings_dl.php` interpolated a username or event title into an HTML attribute using `json_encode()` alone or `addslashes(htmlspecialchars(...))`, neither of which is correct for that context. All now use the `htmlspecialchars(json_encode($v), ENT_QUOTES)` form already used elsewhere. This also fixes a live bug: the delete confirmation was silently broken for any event whose title contains an apostrophe, so the prompt never appeared.
+- **Username format is enforced on every path that sets one.** The rule lives in one `username_format_error()` helper in `auth.php`; the self-service profile editor in `settings.php` previously checked only that the value was non-empty, while registration and the API enforced the documented charset.
+- **Timer themes and blind presets are scoped to their owner.** `load_theme` and `load_preset` now apply the same visibility filter `get_theme` and `get_presets` already used, and `update_theme` and `update_levels` copy-on-edit when the target belongs to someone else, matching the ownership rule their delete counterparts already enforced.
+- **Joining a league requires a confirmed POST.** `join_league.php` performed the membership insert on a bare GET with no CSRF token, so a single top-level navigation could add someone to a league without their agreement. The link now renders a confirmation page naming the league and stating that its owner will be able to see the member's email address and phone number; the write happens on POST with a verified token, the same split `rsvp.php`, `verify_email.php` and `poll.php` already use.
+
 ## [v0.2069] - 2026-08-08
 
 ### Fixed

--- a/www/_event_save.php
+++ b/www/_event_save.php
@@ -64,10 +64,14 @@ function event_save_from_post(PDO $db, array $current, bool $isAdmin, bool $allo
         }
 
         // Creator/manager-added invites auto-approve regardless of the event's requires_approval flag.
-        $ins = $db->prepare("INSERT INTO event_invites (event_id, username, phone, email, rsvp, rsvp_token, rsvp_token_flips, occurrence_date, event_role, approval_status, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'approved', ?)");
+        // user_id links the invite to a real account and is what confers visibility
+        // and co-host authority (see can_manage_event()). It is resolved from the
+        // username only when that username IS an existing account; a typed-in name
+        // for someone with no account stays NULL and grants nothing.
+        $ins = $db->prepare("INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, rsvp_token, rsvp_token_flips, occurrence_date, event_role, approval_status, sort_order) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'approved', ?)");
         // Build a lookup of user contact info for auto-filling
         $userLookup = [];
-        $uAll = $db->query('SELECT username, email, phone FROM users ORDER BY username')->fetchAll();
+        $uAll = $db->query('SELECT id, username, email, phone FROM users ORDER BY username')->fetchAll();
         foreach ($uAll as $uRow) $userLookup[strtolower($uRow['username'])] = $uRow;
 
         for ($i = 0; $i < count($inv_usernames); $i++) {
@@ -95,7 +99,8 @@ function event_save_from_post(PDO $db, array $current, bool $isAdmin, bool $allo
             $token = ($prior['rsvp_token'] ?? '') !== '' ? $prior['rsvp_token'] : bin2hex(random_bytes(16));
             $tokenFlips = (int)($prior['rsvp_token_flips'] ?? 0);
             $sortOrd = $inv_sort_orders[$i] ?? ($i + 1);
-            $ins->execute([$eid, canonical_username($inv_usernames[$i]), $phone_norm ?: null, $email_raw ?: null, $rsvp, $token, $tokenFlips, $invite_occ_date, $role, $sortOrd]);
+            $linked = $userLookup[strtolower(trim($inv_usernames[$i]))]['id'] ?? null;
+            $ins->execute([$eid, canonical_username($inv_usernames[$i]), $linked, $phone_norm ?: null, $email_raw ?: null, $rsvp, $token, $tokenFlips, $invite_occ_date, $role, $sortOrd]);
             // Only track new invitees for base (all-occurrence) saves so notifications go out
             if (!$invite_occ_date && !in_array(strtolower($inv_usernames[$i]), $old_names, true)) {
                 $new_usernames[] = strtolower($inv_usernames[$i]);

--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -1871,7 +1871,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
                         <td class="ug-act-cell">
                             <?php if (!$isSelf): ?>
                             <form method="post" action="/admin_settings.php"
-                                  onsubmit="return pkConfirmForm(this, 'Delete <?= addslashes(htmlspecialchars($u['username'])) ?>? This cannot be undone.', {okLabel:'Delete', danger:true})">
+                                  onsubmit="return pkConfirmForm(this, 'Delete ' + <?= htmlspecialchars(json_encode($u['username']), ENT_QUOTES) ?> + '? This cannot be undone.', {okLabel:'Delete', danger:true})">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="tab" value="users">
@@ -2244,7 +2244,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
 
                         <td class="ev-del-cell">
                             <form method="post" action="/admin_settings.php"
-                                  onsubmit="return pkConfirmForm(this, 'Delete event &quot;<?= addslashes(htmlspecialchars($ev['title'])) ?>&quot;? This cannot be undone.', {okLabel:'Delete', danger:true})">
+                                  onsubmit="return pkConfirmForm(this, 'Delete event ' + <?= htmlspecialchars(json_encode('"' . $ev['title'] . '"'), ENT_QUOTES) ?> + '? This cannot be undone.', {okLabel:'Delete', danger:true})">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                 <input type="hidden" name="action" value="delete_event">
                                 <input type="hidden" name="tab" value="events">

--- a/www/admin_settings_dl.php
+++ b/www/admin_settings_dl.php
@@ -988,7 +988,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
                                    class="btn-icon" title="Edit">&#9881;</a>
                                 <?php if ((int)$u['id'] !== (int)$current['id']): ?>
                                 <form method="post" action="/admin_settings.php"
-                                      onsubmit="return pkConfirmForm(this, 'Delete ' + <?= json_encode($u['username']) ?> + '?', {okLabel:'Delete', danger:true})">
+                                      onsubmit="return pkConfirmForm(this, 'Delete ' + <?= htmlspecialchars(json_encode($u['username']), ENT_QUOTES) ?> + '?', {okLabel:'Delete', danger:true})">
                                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="tab" value="users">

--- a/www/auth.php
+++ b/www/auth.php
@@ -374,6 +374,22 @@ function csrf_token(): string {
     return $_SESSION['csrf_token'];
 }
 
+
+/**
+ * The one username rule. Registration, the API and the self-service profile
+ * editor must agree: authorization joins events to people by username string
+ * (see can_manage_event() / event_visibility_sql() in db.php), so a username
+ * that can contain spaces, an @, or a colon can be pointed at an invite row
+ * belonging to someone else. settings.php used to check only non-emptiness,
+ * which is how "pending:12" and "someone@example.com" became claimable.
+ */
+function username_format_error(string $username): ?string {
+    if (!preg_match('/^[a-zA-Z0-9_]{3,30}$/', $username)) {
+        return 'Username must be 3-30 characters (letters, numbers, underscores).';
+    }
+    return null;
+}
+
 /**
  * Register a new user. Returns null on success or an error string on failure.
  * New users are created with email_verified=0 and must verify before logging in.
@@ -388,8 +404,8 @@ function register_user(string $username, string $email, string $password, string
     if ($username === '' || $password === '') {
         return 'Username and password are required.';
     }
-    if (!preg_match('/^[a-zA-Z0-9_]{3,30}$/', $username)) {
-        return 'Username must be 3-30 characters (letters, numbers, underscores).';
+    if ($err = username_format_error($username)) {
+        return $err;
     }
     if (strlen($password) < MIN_PASSWORD_LENGTH) {
         return 'Password must be at least ' . MIN_PASSWORD_LENGTH . ' characters.';

--- a/www/db.php
+++ b/www/db.php
@@ -1559,6 +1559,24 @@ JSON;
     // or shoulder-surfed QR/email link can't be replayed indefinitely.
     try { $pdo->exec("ALTER TABLE event_invites ADD COLUMN rsvp_token_flips INTEGER NOT NULL DEFAULT 0"); } catch (Exception $e) {}
 
+    // Event authority used to be resolved by matching users.username against the
+    // free-text event_invites.username. Invites for people with no account store
+    // a typed name, an email, a phone or "pending:<id>", so anyone who could
+    // choose that username inherited that invite's visibility and, if it was a
+    // co-host row, full host control of the event. Authority now hangs off this
+    // column instead. NULL means "not a known account", which grants nothing.
+    try { $pdo->exec("ALTER TABLE event_invites ADD COLUMN user_id INTEGER"); } catch (Exception $e) {}
+    try { $pdo->exec("CREATE INDEX IF NOT EXISTS idx_event_invites_user ON event_invites(user_id)"); } catch (Exception $e) {}
+    // One-time backfill from the existing username match. This only records the
+    // access people already had; it grants nothing new. Rows that match no
+    // account stay NULL and stop conferring anything, which is the fix.
+    try {
+        $pdo->exec("UPDATE event_invites
+                       SET user_id = (SELECT u.id FROM users u
+                                       WHERE LOWER(u.username) = LOWER(event_invites.username))
+                     WHERE user_id IS NULL");
+    } catch (Exception $e) {}
+
     // ─── Public league landing pages (/league/<slug>) ───────────────────
     // venue_name is the publishable half of an event's location: shown on public
     // league pages/feeds, while `location` (street address) stays members-only.
@@ -2569,6 +2587,14 @@ function sanitize_html(string $html): string {
             $tag = strtolower($child->nodeName);
 
             if (!in_array($tag, $allowed_tags, true)) {
+                // Walk the subtree BEFORE queueing the unwrap. Unwrapping promotes
+                // this element's children into $node after the loop above has
+                // already finished, so anything not sanitized here is emitted
+                // verbatim: <div><font><img onerror=...></font></div> survived a
+                // full pass, because <font> is not allowed and so was never
+                // walked. One extra wrapper bought one extra pass, which is why
+                // sanitizing twice was not the mitigation it looked like.
+                $walk($child);
                 $to_remove[] = [$child, true]; // unwrap: keep text, drop tag
                 continue;
             }
@@ -2577,6 +2603,7 @@ function sanitize_html(string $html): string {
             if ($tag === 'iframe') {
                 $src = $child->getAttribute('src');
                 if (!$iframe_src_ok($src)) {
+                    $walk($child); // same reason as above
                     $to_remove[] = [$child, true];
                     continue;
                 }
@@ -2760,8 +2787,7 @@ function event_visibility_sql(string $alias = 'e', ?int $user_id = null): array 
            ))
         OR EXISTS (
                SELECT 1 FROM event_invites ei
-               JOIN users u ON LOWER(u.username) = LOWER(ei.username)
-               WHERE ei.event_id = {$alias}.id AND u.id = ?
+               WHERE ei.event_id = {$alias}.id AND ei.user_id = ?
            )
     )";
     return ['sql' => $sql, 'params' => [$user_id, $user_id, $user_id]];
@@ -3106,8 +3132,7 @@ function can_manage_event(PDO $db, int $event_id, int $user_id, bool $is_admin =
     $stmt = $db->prepare("
         SELECT e.created_by, e.league_id,
                (SELECT 1 FROM event_invites ei
-                 JOIN users u ON LOWER(u.username) = LOWER(ei.username)
-                 WHERE ei.event_id = e.id AND u.id = ? AND ei.event_role = 'manager' LIMIT 1) AS is_event_mgr,
+                 WHERE ei.event_id = e.id AND ei.user_id = ? AND ei.event_role = 'manager' LIMIT 1) AS is_event_mgr,
                (SELECT lm.role FROM league_members lm
                  WHERE lm.league_id = e.league_id AND lm.user_id = ? LIMIT 1) AS league_role
         FROM events e WHERE e.id = ?

--- a/www/join_league.php
+++ b/www/join_league.php
@@ -50,6 +50,28 @@ if (league_role($league_id, $uid) !== null) {
     exit;
 }
 
+// Joining is a state change, so it needs an explicit POST with a CSRF token.
+// On a bare GET this used to insert straight into league_members: one top-level
+// navigation (SameSite=Lax still sends the cookie) silently made the victim a
+// member of an attacker-owned league, and a league owner can export every
+// member's email and phone. Same GET-renders / POST-writes split that rsvp.php,
+// verify_email.php and poll.php already use.
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !csrf_verify()) {
+    $auto = $league['approval_mode'] === 'auto';
+    $body = '<p>You have been invited to join <strong>' . htmlspecialchars($league['name']) . '</strong>.</p>'
+          . '<p style="color:#64748b;font-size:.9rem">'
+          . ($auto ? 'Joining adds you to the league straight away.'
+                   : 'Your request will be sent to the league owner for approval.')
+          . ' The owner will be able to see your account\'s email address and phone number.</p>'
+          . '<form method="post" action="/join_league.php?code=' . htmlspecialchars(urlencode($code)) . '" style="margin-top:1rem">'
+          . '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(csrf_token()) . '">'
+          . '<button type="submit" class="btn-primary">'
+          . ($auto ? 'Join league' : 'Request to join')
+          . '</button></form>';
+    render_page($site, $auto ? 'Join league' : 'Request to join', $body, '/leagues.php', 'Not now');
+    exit;
+}
+
 // Handle the join based on approval mode.
 if ($league['approval_mode'] === 'auto') {
     $db->prepare('INSERT INTO league_members (league_id, user_id, role, invited_by, invited_at) VALUES (?, ?, ?, NULL, CURRENT_TIMESTAMP)')

--- a/www/settings.php
+++ b/www/settings.php
@@ -47,8 +47,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $valid_tzs = array_values(get_timezone_options());
             $timezone  = ($tz_in !== '' && in_array($tz_in, $valid_tzs, true)) ? $tz_in : '';
 
+            // Same rule as registration and the API. This path used to accept any
+            // non-empty string, which mattered because event authority is resolved
+            // by matching users.username against event_invites.username: a username
+            // containing a space, an @ or a colon can be aimed at an invite row for
+            // someone who has no account (see can_manage_event() in db.php).
             if ($username === '') {
                 $flash = ['type' => 'error', 'msg' => 'Username cannot be empty.'];
+            } elseif ($err = username_format_error($username)) {
+                $flash = ['type' => 'error', 'msg' => $err];
             } elseif ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
                 $flash = ['type' => 'error', 'msg' => 'A valid email address is required.'];
             } else {

--- a/www/timer_dl.php
+++ b/www/timer_dl.php
@@ -402,8 +402,12 @@ if ($action === 'load_preset') {
     if (!$timer) { echo json_encode(['ok' => false, 'error' => 'Timer not found']); exit; }
     $preset_id = (int)($_POST['preset_id'] ?? 0);
 
-    $p = $db->prepare('SELECT id FROM blind_presets WHERE id = ?');
-    $p->execute([$preset_id]);
+    // Scoped exactly like get_presets() above, for the same reason as load_theme.
+    $p = $db->prepare('SELECT id FROM blind_presets WHERE id = ? AND (is_default = 1
+                OR is_global  = 1
+                OR created_by = ?
+                OR league_id IN (SELECT league_id FROM league_members WHERE user_id = ?))');
+    $p->execute([$preset_id, (int)$current['id'], (int)$current['id']]);
     if (!$p->fetch()) {
         echo json_encode(['ok' => false, 'error' => 'Preset not found']);
         exit;
@@ -542,6 +546,15 @@ if ($action === 'update_levels') {
             $preset_id = (int)$db->lastInsertId();
             $db->prepare("UPDATE timer_state SET preset_id = ?, updated_at = datetime('now') WHERE id = ?")->execute([$preset_id, $timer['id']]);
             $created_copy = true;
+        } elseif ((int)($presetRow['created_by'] ?? 0) !== (int)$current['id'] && !$isAdmin) {
+            // Someone else's personal preset. Falling through here did not just
+            // overwrite it — the code below DELETEs every level row and re-inserts,
+            // so it destroyed another user's saved blind structure. delete_preset
+            // already required ownership; this is the same rule applied to edits.
+            $db->prepare('INSERT INTO blind_presets (name, created_by) VALUES (?, ?)')->execute(['Custom', $current['id']]);
+            $preset_id = (int)$db->lastInsertId();
+            $db->prepare("UPDATE timer_state SET preset_id = ?, updated_at = datetime('now') WHERE id = ?")->execute([$preset_id, $timer['id']]);
+            $created_copy = true;
         }
     }
 
@@ -667,8 +680,14 @@ if ($action === 'load_theme') {
     if (!$timer) { echo json_encode(['ok' => false, 'error' => 'Timer not found']); exit; }
     $theme_id = (int)($_POST['theme_id'] ?? 0);
 
-    $t = $db->prepare('SELECT id, properties FROM timer_themes WHERE id = ?');
-    $t->execute([$theme_id]);
+    // Scoped exactly like get_theme() above. Without this any authenticated user
+    // could point their own timer at any theme id and read it back — and, because
+    // update_theme derives its target from timer_state.theme_id, then overwrite it.
+    $t = $db->prepare('SELECT id, properties FROM timer_themes WHERE id = ? AND (is_default = 1
+                OR is_global  = 1
+                OR created_by = ?
+                OR league_id IN (SELECT league_id FROM league_members WHERE user_id = ?))');
+    $t->execute([$theme_id, (int)$current['id'], (int)$current['id']]);
     $themeRow = $t->fetch();
     if (!$themeRow) { echo json_encode(['ok' => false, 'error' => 'Theme not found']); exit; }
 
@@ -762,6 +781,17 @@ if ($action === 'update_theme') {
            ->execute([$theme_id, $timer['id']]);
         $created_copy = true;
     } elseif ($theme_league_id > 0 && !$isAdmin && !$can_edit_league) {
+        $db->prepare('INSERT INTO timer_themes (name, created_by, properties) VALUES (?, ?, ?)')
+           ->execute(['Custom', $current['id'], json_encode($props)]);
+        $theme_id = (int)$db->lastInsertId();
+        $db->prepare("UPDATE timer_state SET theme_id = ?, updated_at = datetime('now') WHERE id = ?")
+           ->execute([$theme_id, $timer['id']]);
+        $created_copy = true;
+    } elseif ((int)($themeRow['created_by'] ?? 0) !== (int)$current['id'] && !$isAdmin) {
+        // Someone else's personal theme. The chain above covered protected and
+        // league themes but let this case fall through to a bare UPDATE, so any
+        // user could overwrite any other user's theme by id. Copy on edit, the
+        // same as every other branch here, and as delete_theme already required.
         $db->prepare('INSERT INTO timer_themes (name, created_by, properties) VALUES (?, ?, ?)')
            ->execute(['Custom', $current['id'], json_encode($props)]);
         $theme_id = (int)$db->lastInsertId();

--- a/www/user_edit.php
+++ b/www/user_edit.php
@@ -295,7 +295,7 @@ $site_name = get_setting('site_name', 'Game Night');
                 If this user lost their device <em>and</em> their recovery codes, reset it so they can sign in with just their password and re-enroll.
             </p>
             <form method="post" action="/user_edit.php?id=<?= $id ?>"
-                  onsubmit="return pkConfirmForm(this, 'Reset (disable) two-factor for ' + <?= json_encode($target['username']) ?> + '? They will sign in with just their password until they set it up again.', {danger:true})">
+                  onsubmit="return pkConfirmForm(this, 'Reset (disable) two-factor for ' + <?= htmlspecialchars(json_encode($target['username']), ENT_QUOTES) ?> + '? They will sign in with just their password until they set it up again.', {danger:true})">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="reset_mfa">
                 <button type="submit" class="btn" style="width:100%;background:#dc2626;color:#fff;border:none;font-weight:600">Reset Two-Factor</button>
@@ -336,7 +336,7 @@ $site_name = get_setting('site_name', 'Game Night');
             Permanently delete this account and all associated activity logs. This cannot be undone.
         </p>
         <form method="post" action="/user_edit.php?id=<?= $id ?>"
-              onsubmit="return pkConfirmForm(this, 'Permanently delete ' + <?= json_encode($target['username']) ?> + '? This cannot be undone.', {okLabel:'Delete', danger:true})">
+              onsubmit="return pkConfirmForm(this, 'Permanently delete ' + <?= htmlspecialchars(json_encode($target['username']), ENT_QUOTES) ?> + '? This cannot be undone.', {okLabel:'Delete', danger:true})">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
             <input type="hidden" name="action" value="delete">
             <button type="submit" class="btn" style="background:#dc2626;color:#fff">

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2069');
+define('APP_VERSION', '0.2070');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Security

**Event authorization now hangs off an account id rather than a username string.** `event_invites` gains a `user_id` column, backfilled once from the existing username match, and both `can_manage_event()` and `event_visibility_sql()` join on it. An invite row that does not correspond to a real account no longer confers visibility or co-host authority.

Verified access-preserving before shipping: every existing (user, event, role) pair was compared under the old and new logic, none lost and none gained. Deliberate behaviour change worth knowing: an invite typed as a plain name no longer starts granting access if someone later registers under that name, so a host who wants a real co-host adds them once they have an account.

**Hardened HTML sanitization.** `sanitize_html()` did not descend into elements it was about to unwrap, so their contents skipped the tag allowlist, attribute stripping and URL scheme checks. It now sanitizes those subtrees first. Allowed formatting, lists, links and whitelisted embeds are unaffected, verified against a matrix of inputs.

**Corrected escaping in admin confirmation dialogs.** Five `onsubmit` handlers across `user_edit.php`, `admin_settings.php` and `admin_settings_dl.php` interpolated a username or event title into an HTML attribute using `json_encode()` alone or `addslashes(htmlspecialchars(...))`, neither of which is correct for that context. All now use the `htmlspecialchars(json_encode($v), ENT_QUOTES)` form already used elsewhere in the codebase. This also repairs a live bug: the delete confirmation was silently broken for any event titled with an apostrophe, so the prompt never appeared and the delete proceeded unconfirmed.

**Username format is enforced on every path that sets one.** The rule now lives in a single `username_format_error()` helper in `auth.php`. The self-service profile editor checked only that the value was non-empty, while registration and the API enforced the documented charset.

**Timer themes and blind presets are scoped to their owner.** `load_theme` and `load_preset` apply the same visibility filter `get_theme` and `get_presets` already used, and `update_theme` / `update_levels` copy-on-edit when the target belongs to someone else, matching the ownership rule their delete counterparts already enforced.

**Joining a league requires a confirmed POST.** `join_league.php` performed the membership insert on a bare GET with no CSRF token. It now renders a confirmation naming the league and stating that its owner will be able to see the member's email address and phone number; the write happens on POST with a verified token, the same GET-renders / POST-writes split `rsvp.php`, `verify_email.php` and `poll.php` already use.

### Verification

Functional smoke test of every changed flow, driven as a real user: 25 assertions, 0 failures. Covers login, username validation (rejected with message, accepted, persisted, restored), six core pages, event visibility for both a creator and an invitee, the check-in console, a theme save/load/edit round-trip, the league join confirmation and the real POST join, and that every admin `onsubmit` handler parses as valid JS with no stray event handlers. Access preservation was checked pair-by-pair. Full recursive `php -l` sweep clean. Existing timer suites still pass (48 fit assertions, 10 gesture assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)