### PR TITLE
Security: per-request CSP nonce on inline scripts (v0.2072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2072] - 2026-08-09
+
+### Security
+- **Inline scripts now carry a per-request CSP nonce, so an injected `<script>` is refused by the browser.** `auth.php` mints `CSP_NONCE` once per request and `csp_nonce()` stamps it on all 64 inline blocks across 33 files. External `<script src="/...">` needs no nonce, it is covered by `'self'`; `cast_receiver.php` is deliberately excluded, being standalone with no CSP header of its own. The header now carries three script directives rather than one, and the split is the whole trick: adding a nonce to `script-src` makes a browser ignore `'unsafe-inline'` **including for `on*` attributes**, which would break every button in the app, so `script-src-elem` takes the nonce while `script-src-attr` keeps `'unsafe-inline'` until the inline handlers are converted, and a plain `script-src` remains as the fallback for browsers without CSP3 granularity (behaviour there is unchanged). Scope, stated plainly: this blocks injected script **elements**, not injected `on*` **attributes**, so it narrows the gap rather than closing it. Converting the remaining 579 inline handlers to `addEventListener` is the next step, tracked in `SECURITY.md`. Verified across 20 pages with zero CSP violations, inline scripts confirmed executing (not merely present), inline handlers confirmed still firing, and the nonce confirmed to change per request.
+
 ## [v0.2071] - 2026-08-09
 
 ### Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Working notes for this codebase: the checks to run before shipping, and the one
 known hardening gap that has not been closed yet. Kept in the repo so neither
 gets lost between sessions.
 
-Last reviewed: 2026-08-09 (v0.2071).
+Last reviewed: 2026-08-09 (v0.2072).
 
 ---
 
@@ -76,10 +76,13 @@ script-src 'self' 'unsafe-inline'
 
 `'self'` stops an attacker loading script from another origin. `'unsafe-inline'`
 additionally permits script written inside the HTML, covering both `<script>`
-blocks and `onclick="…"` attributes. Because the browser cannot distinguish the
-app's own inline script from an injected one, **the CSP currently provides no XSS
-mitigation**. Every XSS issue found in the v0.2070 review would have executed
-without friction.
+blocks and `onclick="…"` attributes. Because the browser cannot distinguish the app's own inline script from an
+injected one, **the CSP originally provided no XSS mitigation at all** — every
+XSS issue found in the v0.2070 review would have executed without friction.
+
+As of v0.2072 that is partly closed: injected `<script>` elements are blocked by
+the nonce (see step 1 below). Injected `on*` attributes still execute, so the
+gap is narrowed, not shut.
 
 ### Why it is still there
 
@@ -87,8 +90,8 @@ It is load-bearing. As of 2026-08-09:
 
 | | Count |
 |---|---|
-| Inline `on*` handler attributes | 579 |
-| Inline `<script>` blocks | 62 |
+| Inline `on*` handler attributes | 579 (the remaining work) |
+| Inline `<script>` blocks | 64, all nonced as of v0.2072 |
 | External `.js` files | 6 |
 
 `checkin.php` has 165 inline handlers and `timer.php` 154. Removing the directive
@@ -97,10 +100,21 @@ today breaks the application completely.
 ### Why a nonce is only half a fix
 
 A nonce authorizes a `<script>` block. **There is no syntax to nonce an `on*`
-attribute** — inline event handlers cannot be authorized under a strict CSP at
-all. They have to become `addEventListener` with their data carried in `data-`
-attributes. Most of this codebase's handlers are built inside JS strings at
-runtime, e.g.
+attribute** — inline event handlers cannot be authorized by nonce at all. They
+have to become `addEventListener` with their data carried in `data-` attributes.
+
+Note the trap: adding a nonce to `script-src` makes a browser **ignore
+`'unsafe-inline'` entirely**, which blocks event handler attributes too. Done
+naively that breaks every button on the site. The split is what makes step 1
+shippable on its own:
+
+| Directive | Purpose |
+|---|---|
+| `script-src 'self' 'unsafe-inline'` | fallback for browsers without CSP3 granularity (Firefox); behaviour there is unchanged |
+| `script-src-elem 'self' 'nonce-…'` | script **elements** must carry the nonce, so an injected `<script>` is refused |
+| `script-src-attr 'unsafe-inline'` | event handler **attributes** stay allowed until they are converted |
+
+Most of this codebase's handlers are built inside JS strings at runtime, e.g.
 
 ```js
 h += '<button onclick="toggleBuyin(' + p.id + ')">';
@@ -110,10 +124,14 @@ which is exactly the pattern that has to move to event delegation.
 
 ### Agreed path, each step independently shippable
 
-1. **Add a per-request nonce and keep `'unsafe-inline'` alongside it.** Browsers
-   ignore `'unsafe-inline'` for script blocks once a nonce is present, so this
-   hardens the 62 blocks immediately while attribute handlers keep working.
-   Roughly an hour, low risk.
+1. ~~**Add a per-request nonce** via the three-directive split above.~~ **Done in
+   v0.2072.** `auth.php` mints a per-request `CSP_NONCE`; `csp_nonce()` stamps it
+   on all 64 inline blocks across 33 files. External `<script src="/...">` needs
+   no nonce, it is covered by `'self'`. `cast_receiver.php` is excluded: it is
+   standalone, sends no CSP header, and must not call `csp_nonce()`.
+   **What this buys:** an injected `<script>` element is now refused by the
+   browser. **What it does not:** an injected `on*` attribute still runs, since
+   `script-src-attr` still allows them. That is what step 2 closes.
 2. **Convert handlers file by file**, smallest first (`_nav.php` 7,
    `_post_card.php` 9) to settle the delegation pattern before touching
    `checkin.php` and `timer.php`.

--- a/www/_footer.php
+++ b/www/_footer.php
@@ -44,7 +44,7 @@ if ($_hb_user) {
             'preview'   => false,
         ];
         ?>
-        <script>window.__help = <?= json_encode($_hb_payload, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;</script>
+        <script nonce="<?= csp_nonce() ?>">window.__help = <?= json_encode($_hb_payload, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;</script>
         <script src="/help-bubble.js?v=<?= htmlspecialchars(APP_VERSION) ?>" defer></script>
         <?php
     }
@@ -56,7 +56,7 @@ if ($_hb_user) {
    once stored, this block stops emitting on the next page load. */
 if ($_hb_user && empty($_hb_user['timezone'])) {
     ?>
-    <script>
+    <script nonce="<?= csp_nonce() ?>">
     (function () {
         try {
             var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -74,7 +74,7 @@ if ($_hb_user && empty($_hb_user['timezone'])) {
 }
 ?>
 <?php /* Segmented control + slide engine. Deliberately NOT deferred: a page may
-         put its own inline <script> after this footer (checkin.php does), and it
+         put its own inline <script nonce="<?= csp_nonce() ?>"> after this footer (checkin.php does), and it
          must see these functions already defined. Tiny, and already at the end
          of the body, so blocking is a non-issue. */ ?>
 <script src="/pk-seg.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/pk-seg.js') ?: 0)) ?>"></script>
@@ -86,7 +86,7 @@ if ($_hb_user && empty($_hb_user['timezone'])) {
     updates the nav bell / Messages badges in place. Plays a short two-note
     chime when the total rises (browsers allow audio only after the user has
     interacted with the page — until then it updates silently). */ ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 (function () {
     var KEY = 'gn_notif_seen';
     function setBadge(cls, n) {

--- a/www/_nav.php
+++ b/www/_nav.php
@@ -187,7 +187,7 @@ $_accent        = get_setting('accent_color', '');
     </div>
 </nav>
 <?php if ($_banner): ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 (function(){
     var l = document.querySelector('link[rel~="icon"]');
     if (!l) { l = document.createElement('link'); l.rel = 'icon'; document.head.appendChild(l); }
@@ -225,7 +225,7 @@ nav.nav-collapsed .nav-top{justify-content:space-between}
 .nav-account-name{font-weight:700;font-size:.9rem;color:#fff;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .nav-menu-count{background:#dc2626;color:#fff;font-size:.65rem;font-weight:700;border-radius:999px;padding:.05rem .35rem;margin-left:.35rem;vertical-align:middle}
 </style>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 function toggleNavCollapse(){
     var nav=document.getElementById('mainNav');
     if(!nav)return;

--- a/www/admin_help.php
+++ b/www/admin_help.php
@@ -183,7 +183,7 @@ $tips = $tipsStmt->fetchAll();
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 const CSRF   = <?= json_encode($token) ?>;
 const SCREEN = <?= json_encode($screen) ?>;
 let TIPS     = <?= json_encode($tips, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -472,7 +472,7 @@ $now_local = (new DateTime('now', $local_tz))->format('Y-m-d H:i:s');
 <?php require __DIR__ . '/_footer.php'; ?>
 
 <script src="/vendor/jodit/jodit.min.js" defer></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 const csrfToken = <?= json_encode($token) ?>;
 
 // ── Jodit setup ───────────────────────────────────────────────────────────────

--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -1256,7 +1256,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
             </div>
         </div>
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         (function(){
             var CSRF = <?= json_encode($token) ?>;
             function esc(s){ var d=document.createElement('div'); d.textContent=(s==null?'':String(s)); return d.innerHTML; }
@@ -1891,7 +1891,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
 
         <div class="ug-save-indicator" id="ugSaveIndicator">Saved</div>
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         (function () {
             const csrf = <?= json_encode($token) ?>;
             const ind  = document.getElementById('ugSaveIndicator');
@@ -2263,7 +2263,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
 
         <div class="ev-save-indicator" id="evSaveIndicator">Saved</div>
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         (function () {
             const csrf   = <?= json_encode($token) ?>;
             const ind    = document.getElementById('evSaveIndicator');
@@ -2380,7 +2380,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
             <?php endif; ?>
         </div>
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         function filterAdminLeagues(q) {
             q = (q || '').trim().toLowerCase();
             var rows = document.querySelectorAll('.admin-lg-row');
@@ -2741,7 +2741,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
         </div>
 
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         function toggleSmsFields() {
             var p = document.getElementById('sms_provider').value;
             document.querySelectorAll('.sms-field').forEach(function(el) {
@@ -2845,7 +2845,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
         </div>
     </div>
 
-    <script>
+    <script nonce="<?= csp_nonce() ?>">
     var WAHA_URL = <?= json_encode($waha_url, JSON_HEX_TAG) ?>;
     var WAHA_SESSION = <?= json_encode($waha_session, JSON_HEX_TAG) ?>;
     var WAHA_CSRF = <?= json_encode($token, JSON_HEX_TAG) ?>;
@@ -3228,7 +3228,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 function openUserModal() {
     document.getElementById('newUserModal').classList.add('open');
     document.getElementById('m_username').focus();
@@ -3271,6 +3271,6 @@ function updatePreview() {
 }
 </script>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/admin_settings_dl.php
+++ b/www/admin_settings_dl.php
@@ -1165,7 +1165,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 function openUserModal() {
     document.getElementById('newUserModal').classList.add('open');
     document.getElementById('m_username').focus();

--- a/www/auth.php
+++ b/www/auth.php
@@ -19,9 +19,24 @@ $_frame_src = "frame-src https://www.youtube.com https://www.youtube-nocookie.co
 try {
     foreach (stream_allowed_hosts() as $_h) { $_frame_src .= ' https://' . $_h; }
 } catch (\Throwable $e) { /* keep the built-in frame-src */ }
+// Per-request nonce for inline <script> blocks. See SECURITY.md.
+// Why three script directives instead of one:
+//   script-src       fallback for browsers without CSP3 granularity (Firefox).
+//                    Keeps 'unsafe-inline' so behaviour there is unchanged.
+//   script-src-elem  script ELEMENTS must carry this nonce. Adding a nonce makes
+//                    a browser ignore 'unsafe-inline', so an injected <script> is
+//                    refused — which is the point.
+//   script-src-attr  event handler ATTRIBUTES stay allowed for now. They cannot
+//                    be nonced (there is no syntax for it), so until the ~579
+//                    inline on* handlers become addEventListener they need their
+//                    own directive or every button on the site stops working.
+if (!defined('CSP_NONCE')) define('CSP_NONCE', base64_encode(random_bytes(16)));
+
 $_csp = implode('; ', [
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline'",
+    "script-src-elem 'self' 'nonce-" . CSP_NONCE . "'",
+    "script-src-attr 'unsafe-inline'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https://*.ytimg.com https://*.twitch.tv https://*.jtvnw.net",
     "object-src 'none'",
@@ -40,6 +55,16 @@ if ((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || (($_SERVER['HT
 
 // ── Mobile detection (available to all pages) ────────────────────────────────
 $_is_mobile = (bool) preg_match('/Mobile|Android|iPhone|iPad|iPod|CriOS|FxiOS/i', $_SERVER['HTTP_USER_AGENT'] ?? '');
+
+/**
+ * Nonce for an inline script block: <script nonce="<?= csp_nonce() ?>">.
+ * Required by script-src-elem. External <script src="/..."> does not need one,
+ * it is covered by 'self'. Pages that do not include auth.php (cast_receiver.php)
+ * get no CSP header and must NOT call this.
+ */
+function csp_nonce(): string {
+    return defined('CSP_NONCE') ? CSP_NONCE : '';
+}
 
 function _is_https(): bool {
     return (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -1863,7 +1863,7 @@ $editorCtx = ($wkStart !== null) ? 'wk=' . urlencode($wkStartStr) : 'm=' . urlen
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 let currentEvent = null;
 const eventComments      = <?= json_encode($ev_comments, JSON_HEX_TAG) ?>;
 /* (object) cast keeps the top level an object (incl. empty {}) WITHOUT JSON_FORCE_OBJECT,
@@ -3227,7 +3227,7 @@ function copyWalkinLink() {
     </div>
 </div>
 <script src="/vendor/jodit/jodit.min.js" defer></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 let _emEditor = null;
 function _emEnsureEditor() {
     if (_emEditor || typeof Jodit === 'undefined') return;

--- a/www/checkin.php
+++ b/www/checkin.php
@@ -766,7 +766,7 @@ $session = $sessStmt->fetch();
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf, JSON_HEX_TAG) ?>;
 var ALL_USERS = <?= json_encode($allUsernames, JSON_HEX_TAG) ?>;
 var EVENT_ID = <?= $event_id ?>;

--- a/www/contact_edit.php
+++ b/www/contact_edit.php
@@ -114,7 +114,7 @@ $canMsg   = $isLinked && (int)$c['linked_user_id'] !== $uid;
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
 <script src="/_phone_input.js"></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 initPhoneAutoFormat();
 var CSRF = <?= json_encode($csrf) ?>;
 var CID = <?= $cid ?>;

--- a/www/contacts.php
+++ b/www/contacts.php
@@ -200,7 +200,7 @@ $prefLabels = ['email' => 'Email', 'sms' => 'Text', 'whatsapp' => 'WhatsApp', 'b
     <?php endif; ?>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 
 function post(data) {
@@ -229,6 +229,6 @@ function addContact() {
 
 <?php require __DIR__ . '/_footer.php'; ?>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/event.php
+++ b/www/event.php
@@ -441,7 +441,7 @@ if ($token === '' && $page_eid > 0) {
         </div>
     </div>
 </div>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 (function () {
     var CSRF = <?= json_encode($csrf) ?>;
     var EID  = <?= (int)$page_eid ?>;
@@ -656,7 +656,7 @@ async function editComment(id) {
      which loads the stylesheet (calendar.php) as do league.php and admin_posts.php. -->
 <link rel="stylesheet" href="/vendor/jodit/jodit.min.css">
 <script src="/vendor/jodit/jodit.min.js" defer></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // ── Manager panel: live roster, approvals, delivery status, invites ─────────
 // Ported from the calendar popup (renderInvitesPanel/pollRsvps) — one view now.
 var NOTIFS_ON   = <?= $notifsEnabled ? 'true' : 'false' ?>;

--- a/www/event_edit.php
+++ b/www/event_edit.php
@@ -615,7 +615,7 @@ $pageHeading = $isCopy ? 'Duplicate Event' : ($event ? 'Edit Event' : 'Add Event
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // ── Server-provided state ─────────────────────────────────────────────────────
 const CSRF              = <?= json_encode($token, JSON_HEX_TAG) ?>;
 const IS_ADMIN          = <?= $isAdmin ? 'true' : 'false' ?>;

--- a/www/event_polls.php
+++ b/www/event_polls.php
@@ -297,7 +297,7 @@ $backUrl   = '/calendar.php?m=' . urlencode(substr($event['start_date'], 0, 7)) 
 
 <?php require __DIR__ . '/_footer.php'; ?>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var qIdx = 0;
 function addQuestion() {
     var wrap = document.getElementById('plQuestions');

--- a/www/index.php
+++ b/www/index.php
@@ -657,7 +657,7 @@ endif; ?>
 </div><!-- /.posts-wrap -->
 </div><!-- /.page-layout -->
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // ── Timeline active-month highlight (scroll-tracked) ─────────────────────────
 <?php if (!$monthFilter): ?>
 (function () {
@@ -787,7 +787,7 @@ endif; ?>
 })();
 </script>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 function toggleComments(postId) {
     const body = document.getElementById('cmts-body-' + postId);
     const hdr  = body.previousElementSibling;
@@ -798,7 +798,7 @@ function toggleComments(postId) {
 </script>
 
 <?php if ($user): ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 const _csrf = <?= json_encode($csrf) ?>;
 
 function editComment(id, btn) {
@@ -880,7 +880,7 @@ function prepareBulkDelete(postId, form) {
 <?php endif; ?>
 
 <?php if ($user): ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // Per-post kebab menu + personal hide/unhide. Delegated on document so cards
 // loaded later by infinite scroll work without re-binding.
 (function () {

--- a/www/league.php
+++ b/www/league.php
@@ -999,7 +999,7 @@ function ordinal($n) {
                 <button type="submit">Apply</button>
             </span>
         </form>
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         function onRangeChange(sel) {
             var cr = document.getElementById('custom-range');
             if (sel.value === 'custom') { cr.style.display = ''; }
@@ -1302,7 +1302,7 @@ function ordinal($n) {
         </div>
         <script src="/vendor/jodit/jodit.min.js" defer></script>
         <link rel="stylesheet" href="/vendor/jodit/jodit.min.css">
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
             // Jodit must be initialized only after the editor's container is visible;
             // initializing inside a display:none parent causes height/toolbar glitches.
             // For edit mode the form starts open, so we init immediately. For "new post"
@@ -1477,7 +1477,7 @@ function ordinal($n) {
         </div>
         <?php endforeach; endif; ?>
 
-        <script>
+        <script nonce="<?= csp_nonce() ?>">
         function toggleComments(pid) {
             var body = document.getElementById('cmts-body-' + pid);
             if (!body) return;
@@ -1800,7 +1800,7 @@ function ordinal($n) {
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF      = <?= json_encode($csrf) ?>;
 var LEAGUE_ID = <?= $league_id ?>;
 
@@ -2104,6 +2104,6 @@ function escapeHtml(s) {
 
 <?php require __DIR__ . '/_footer.php'; ?>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/league_edit.php
+++ b/www/league_edit.php
@@ -96,7 +96,7 @@ $vals = $league ?: [
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 var IS_EDIT = <?= $isEdit ? 'true' : 'false' ?>;
 var LEAGUE_ID = <?= $isEdit ? $league_id : 0 ?>;

--- a/www/league_public.php
+++ b/www/league_public.php
@@ -461,7 +461,7 @@ $autoJoin = $user && $myRole === null && !$pending && ($_GET['join'] ?? '') === 
     <?php endif; ?>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 function lpToggleCal() {
     var box    = document.getElementById('lp-cal');
     var link   = document.getElementById('lp-cal-toggle');
@@ -485,7 +485,7 @@ function lpCopyCal() {
 </script>
 
 <?php if ($user && $myRole === null && !$pending): ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 (function () {
     var btn  = document.getElementById('lp-join-btn');
     var note = document.getElementById('lp-join-note');

--- a/www/leagues.php
+++ b/www/leagues.php
@@ -176,7 +176,7 @@ $csrf = csrf_token();
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 var _rqLeagueId = null;
 

--- a/www/login.php
+++ b/www/login.php
@@ -273,7 +273,7 @@ $site_name = get_setting('site_name', 'Game Night');
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 document.querySelectorAll('button[aria-label="Show password"], button[aria-label="Hide password"]').forEach(function(btn) {
     function toggle(e) {
         e.preventDefault();

--- a/www/message_thread.php
+++ b/www/message_thread.php
@@ -193,7 +193,7 @@ $lastId = $messages ? (int)end($messages)['id'] : 0;
     </div>
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 var CONV = <?= $conv ? (int)$conv['id'] : 0 ?>;
 var OTHER = <?= $other ? (int)$other['id'] : 0 ?>;

--- a/www/messages.php
+++ b/www/messages.php
@@ -150,7 +150,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <?php endif; ?>
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 
 function createGroup(btn) {

--- a/www/mfa_setup.php
+++ b/www/mfa_setup.php
@@ -231,7 +231,7 @@ $site_name = get_setting('site_name', 'Game Night');
 
 <?php if ($totp_uri): ?>
 <script src="/vendor/qrcode.min.js" defer></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // qrcode.min.js is deferred, so draw on DOMContentLoaded (deferred scripts
 // are guaranteed to have run by then).
 document.addEventListener('DOMContentLoaded', function () {

--- a/www/register.php
+++ b/www/register.php
@@ -308,7 +308,7 @@ $site_name = get_setting('site_name', 'Game Night');
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 document.querySelectorAll('button[aria-label="Show password"], button[aria-label="Hide password"]').forEach(function(btn) {
     function toggle(e) {
         e.preventDefault();
@@ -400,7 +400,7 @@ function syncNotify() {
 updateContactHint();
 </script>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 <script src="/pk-dialogs.js?v=<?= @filemtime(__DIR__ . '/pk-dialogs.js') ?>" defer></script>
 </body>
 </html>

--- a/www/register_dl.php
+++ b/www/register_dl.php
@@ -184,7 +184,7 @@ $site_name = get_setting('site_name', 'Game Night');
     </div>
 </div>
 
-<script>
+<script nonce="<?= csp_nonce() ?>">
 document.querySelectorAll('button[aria-label="Show password"], button[aria-label="Hide password"]').forEach(function(btn) {
     function toggle(e) {
         e.preventDefault();
@@ -200,6 +200,6 @@ document.querySelectorAll('button[aria-label="Show password"], button[aria-label
 });
 </script>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/settings.php
+++ b/www/settings.php
@@ -306,7 +306,7 @@ $site_name = get_setting('site_name', 'Game Night');
                 <input type="hidden" name="action" value="set_avatar">
                 <input type="hidden" name="avatar_path" id="stAvatarPath">
             </form>
-            <script>
+            <script nonce="<?= csp_nonce() ?>">
             document.getElementById('stAvatarFile').addEventListener('change', function () {
                 var f = this.files && this.files[0];
                 if (!f) return;
@@ -573,6 +573,6 @@ $site_name = get_setting('site_name', 'Game Night');
 
 <?php require __DIR__ . '/_footer.php'; ?>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/sms_conversations.php
+++ b/www/sms_conversations.php
@@ -171,7 +171,7 @@ if ($mode === 'thread') {
     <div class="conv-err" id="convError" style="display:none"></div>
     <p class="conv-note">Sent as <?= $channel === 'whatsapp' ? 'WhatsApp' : 'SMS' ?> from the shared number. Texts over 160 characters go out as multiple segments. Conversations are part of the notification log and are kept for 90 days.</p>
 
-    <script>
+    <script nonce="<?= csp_nonce() ?>">
     (function () {
         var eventId = <?= (int)$f_event ?>, phone = <?= json_encode($f_phone) ?>, lastId = <?= (int)$last_id ?>;
         var thread = document.getElementById('convThread');
@@ -300,7 +300,7 @@ if ($mode === 'thread') {
             </tbody>
         </table>
     </div>
-    <script>
+    <script nonce="<?= csp_nonce() ?>">
     document.querySelectorAll('.assign-btn').forEach(function (btn) {
         btn.addEventListener('click', function () {
             var row = btn.closest('tr');

--- a/www/support.php
+++ b/www/support.php
@@ -93,7 +93,7 @@ $utc_tz    = new DateTimeZone('UTC');
     <?php endforeach; endif; ?>
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 var SHOT_PATH = '';
 

--- a/www/support_ticket.php
+++ b/www/support_ticket.php
@@ -107,7 +107,7 @@ $utc_tz    = new DateTimeZone('UTC');
     </div>
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var CSRF = <?= json_encode($csrf) ?>;
 var TID = <?= (int)$ticket['id'] ?>;
 var SHOT_PATH = '';

--- a/www/timer.php
+++ b/www/timer.php
@@ -28,8 +28,8 @@
  *          §5.7  #saveThemeOverlay     save theme as
  *          §5.8  #confirmSaveOverlay   theme save confirm
  *          §5.9  #soundOverlay         sound settings
- *  §6    Vendor <script>s — qrcode.min.js, nosleep.min.js
- *  §7    Inline <script> (~3,600 lines)
+ *  §6    Vendor <script nonce="<?= csp_nonce() ?>">s — qrcode.min.js, nosleep.min.js
+ *  §7    Inline <script nonce="<?= csp_nonce() ?>"> (~3,600 lines)
  *          §7.1   Config from PHP (CSRF, TIMER, LEVELS, SOUNDS, IS_REMOTE, ...)
  *          §7.2   Formatters (fmtTime, fmtMoney, fmtChips, fmtBreakClock, ...)
  *          §7.3   Render (renderAll, renderClock, renderPlayBtn, appendTimerId)
@@ -291,7 +291,7 @@ $themeCss   = timer_theme_css_vars($themeProps);
     <link rel="icon" href="/favicon.php">
     <link rel="stylesheet" href="/style.css?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/style.css') ?: 0)) ?>">
     <link rel="stylesheet" href="/vendor/fonts/fonts.css">
-    <script>window.TIMER_THEME = <?= json_encode($themeProps, JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>; window.TIMER_THEME_ID = <?= $themeId ? (int)$themeId : 'null' ?>;</script>
+    <script nonce="<?= csp_nonce() ?>">window.TIMER_THEME = <?= json_encode($themeProps, JSON_HEX_TAG|JSON_HEX_AMP|JSON_HEX_APOS|JSON_HEX_QUOT) ?>; window.TIMER_THEME_ID = <?= $themeId ? (int)$themeId : 'null' ?>;</script>
     <style id="themeStyle"><?= $themeCss ?></style>
     <style>
         html {
@@ -1970,7 +1970,7 @@ $themeCss   = timer_theme_css_vars($themeProps);
 
 <script src="/vendor/qrcode.min.js"></script>
 <script src="/vendor/nosleep.min.js"></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 // ─── §7.1  Config from PHP ──────────────────────────────────────
 var IS_REMOTE = <?= json_encode($is_remote) ?>;
 var IS_GUEST = <?= json_encode($is_guest) ?>;

--- a/www/user_edit.php
+++ b/www/user_edit.php
@@ -351,6 +351,6 @@ $site_name = get_setting('site_name', 'Game Night');
 
 <?php require __DIR__ . '/_footer.php'; ?>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2071');
+define('APP_VERSION', '0.2072');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and

--- a/www/walkin.php
+++ b/www/walkin.php
@@ -501,6 +501,6 @@ $csrf_token = csrf_token();
     </div>
 </div>
 <script src="/_phone_input.js"></script>
-<script>initPhoneAutoFormat();</script>
+<script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/walkin_display.php
+++ b/www/walkin_display.php
@@ -173,7 +173,7 @@ if (!empty($event['start_time'])) {
 </div>
 
 <script src="/vendor/qrcode.min.js" defer></script>
-<script>
+<script nonce="<?= csp_nonce() ?>">
 var EVENT_ID = <?= $event_id ?>;
 var WALKIN_URL = <?= json_encode($walkin_url) ?>;
 var CSRF = <?= json_encode($csrf) ?>;


### PR DESCRIPTION
### Security

**Inline scripts now carry a per-request CSP nonce, so an injected `<script>` is refused by the browser.**

`auth.php` mints `CSP_NONCE` once per request and `csp_nonce()` stamps it on all **64 inline blocks across 33 files**. External `<script src="/...">` needs no nonce, it is covered by `'self'`. `cast_receiver.php` is deliberately excluded: it is standalone, sends no CSP header, and must not call `csp_nonce()`.

### Why three script directives instead of one

This is the part worth reading, because the obvious approach breaks the site. Adding a nonce to `script-src` makes a browser **ignore `'unsafe-inline'` entirely, including for `on*` attributes**, and this codebase has 579 of those. The split keeps step 1 shippable on its own:

| Directive | Role |
|---|---|
| `script-src 'self' 'unsafe-inline'` | fallback for browsers without CSP3 granularity (Firefox); behaviour there is unchanged |
| `script-src-elem 'self' 'nonce-…'` | script **elements** must carry the nonce |
| `script-src-attr 'unsafe-inline'` | handler **attributes** stay allowed until step 2 converts them |

### Scope, stated plainly

This blocks injected script **elements**. It does **not** block injected `on*` **attributes**, which is the form most of the v0.2070 XSS findings took. The gap is narrowed, not closed. Converting the remaining 579 handlers to `addEventListener` is step 2, tracked in `SECURITY.md`, and this change is the prerequisite that lets it happen in pieces.

### Verification

29 assertions, 0 failures. The two at opposite ends matter most: an injected nonce-less `<script>` is **blocked**, and inline `on*` handlers **still execute**. Plus: nonce present in header and on tags and **regenerated per request** (a fixed nonce would be worthless); **zero CSP script violations across 20 pages** including timer, check-in, admin settings and the event editor; and inline scripts confirmed to have actually executed, by checking globals only they define, rather than merely being present in the DOM.

Regression suites green: 25 security smoke, 48 timer-fit, 10 gesture, both documented pre-push sweeps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)