### PR TITLE
Security: convert nav and post-card inline handlers to delegation (v0.2073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2073] - 2026-08-09
+
+### Security
+- **Inline event handlers removed from the nav and the post card, the first step toward dropping `script-src-attr 'unsafe-inline'`.** Inline `on*` attributes cannot be authorized by a CSP nonce, so they have to go before that directive can be tightened. `_nav.php` (7 handlers) and `_post_card.php` (9) are now at zero: controls carry `data-nav` / `data-pc` attributes and are dispatched by delegated listeners on `document`. Nav dispatch lives in the existing external `nav.js`, which needs no nonce since it is covered by `'self'`; post-card dispatch sits in `index.php` beside the functions it calls. Delegation rather than per-element binding is a requirement here, not a preference: `posts_chunk.php` injects further cards by AJAX after load. Form confirmations move to a reusable `data-confirm` / `data-confirm-ok` / `data-confirm-danger` trio handled by one `submit` listener that calls the existing `pkConfirmForm()`. Tree-wide count is 579 down to 564; `checkin.php` (165) and `timer.php` (154) remain, and the established pattern is written up in `SECURITY.md`.
+
 ## [v0.2072] - 2026-08-09
 
 ### Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Working notes for this codebase: the checks to run before shipping, and the one
 known hardening gap that has not been closed yet. Kept in the repo so neither
 gets lost between sessions.
 
-Last reviewed: 2026-08-09 (v0.2072).
+Last reviewed: 2026-08-09 (v0.2073).
 
 ---
 
@@ -90,7 +90,7 @@ It is load-bearing. As of 2026-08-09:
 
 | | Count |
 |---|---|
-| Inline `on*` handler attributes | 579 (the remaining work) |
+| Inline `on*` handler attributes | 564 (was 579; `_nav.php` and `_post_card.php` converted in v0.2073) |
 | Inline `<script>` blocks | 64, all nonced as of v0.2072 |
 | External `.js` files | 6 |
 
@@ -132,9 +132,26 @@ which is exactly the pattern that has to move to event delegation.
    **What this buys:** an injected `<script>` element is now refused by the
    browser. **What it does not:** an injected `on*` attribute still runs, since
    `script-src-attr` still allows them. That is what step 2 closes.
-2. **Convert handlers file by file**, smallest first (`_nav.php` 7,
-   `_post_card.php` 9) to settle the delegation pattern before touching
-   `checkin.php` and `timer.php`.
+2. **Convert handlers file by file**, smallest first, to settle the delegation
+   pattern before touching `checkin.php` (165) and `timer.php` (154).
+   **Started in v0.2073:** `_nav.php` (7) and `_post_card.php` (9) are at zero.
+   The established pattern:
+   - Tag the control with a `data-*` attribute carrying whatever the old handler
+     passed as arguments (`data-nav="dropdown"`, `data-pc="toggle-comments"
+     data-post="12"`).
+   - Dispatch from a **delegated listener on `document`**, not a per-element
+     binding. Delegation is required, not stylistic: `posts_chunk.php` injects
+     cards by AJAX after load, and per-element listeners would miss them.
+   - Prefer an existing **external** `.js` file as the destination (`nav.js`).
+     External scripts are covered by `'self'` and need no nonce. Otherwise put
+     the listener in the page's nonced block, next to the functions it calls.
+   - For `onsubmit="return pkConfirmForm(...)"` use the generic
+     `data-confirm="…" data-confirm-ok="…" data-confirm-danger="1"` handled by
+     one delegated `submit` listener. `pkConfirmForm()` calls `formEl.submit()`,
+     which does not re-fire the submit event, so it cannot recurse.
+   - When testing a conversion, make sure the fixture actually exists. A check
+     that skips because no post card rendered will report a pass for work it
+     never verified.
 3. **Drop `'unsafe-inline'`** only once the count reaches zero, after running
    `Content-Security-Policy-Report-Only` for a while to catch stragglers.
 

--- a/www/_nav.php
+++ b/www/_nav.php
@@ -93,7 +93,7 @@ $_accent        = get_setting('accent_color', '');
                 <!-- Account avatar + personal menu (Notifications, Messages, My Events, Contacts, Settings, Sign out) -->
                 <div class="nav-dropdown-wrap nav-account-wrap">
                     <button type="button" class="nav-avatar-btn" title="Your account"
-                            onclick="var d=this.nextElementSibling;d.style.display=d.style.display==='block'?'none':'block';">
+                            data-nav="dropdown">
                         <?= avatar_html($_nu['username'], $_nu['avatar_path'] ?? null, 34) ?>
                         <span class="js-avatar-badge nav-avatar-badge" style="<?= $_combined > 0 ? '' : 'display:none' ?>"><?= $_combined > 99 ? '99+' : $_combined ?></span>
                     </button>
@@ -113,7 +113,7 @@ $_accent        = get_setting('accent_color', '');
                 </div>
                 <!-- Hamburger = site navigation only -->
                 <div class="nav-dropdown-wrap">
-                    <button class="nav-hamburger" title="Menu" onclick="var d=this.nextElementSibling;d.style.display=d.style.display==='block'?'none':'block';">&#9776;</button>
+                    <button class="nav-hamburger" title="Menu" data-nav="dropdown">&#9776;</button>
                     <div class="nav-dropdown">
                         <!-- Page links shown only on mobile (nav-links row hidden) -->
                         <a href="/" class="nav-mobile-link<?= $_active === 'home' ? ' active' : '' ?>">Home</a>
@@ -128,7 +128,7 @@ $_accent        = get_setting('accent_color', '');
                         <a href="<?= htmlspecialchars($_timer_href, ENT_QUOTES) ?>" class="nav-mobile-link">Tournament Timer</a>
                         <div class="nav-mobile-divider"></div>
                         <div class="nav-help-group<?= $_active === 'help' || $_active === 'support' ? ' open' : '' ?>">
-                            <button type="button" class="nav-help-toggle" onclick="this.parentElement.classList.toggle('open');">Help <span class="nav-help-caret" aria-hidden="true">&#9656;</span></button>
+                            <button type="button" class="nav-help-toggle" data-nav="help">Help <span class="nav-help-caret" aria-hidden="true">&#9656;</span></button>
                             <div class="nav-help-sub">
                                 <a href="/help-hosts.php">Host Guide</a>
                                 <a href="/help-guests.php">Guest Guide</a>
@@ -139,14 +139,14 @@ $_accent        = get_setting('accent_color', '');
                 </div>
             <?php else: ?>
                 <div class="nav-dropdown-wrap">
-                    <button class="nav-hamburger" title="Menu" onclick="var d=this.nextElementSibling;d.style.display=d.style.display==='block'?'none':'block';">&#9776;</button>
+                    <button class="nav-hamburger" title="Menu" data-nav="dropdown">&#9776;</button>
                     <div class="nav-dropdown">
                         <?php if (get_setting('show_landing_page', '0') !== '1'): ?>
                         <a href="/timer.php" class="nav-mobile-link">Tournament Timer</a>
                         <div class="nav-mobile-divider"></div>
                         <?php endif; ?>
                         <div class="nav-help-group<?= $_active === 'help' ? ' open' : '' ?>">
-                            <button type="button" class="nav-help-toggle" onclick="this.parentElement.classList.toggle('open');">Help <span class="nav-help-caret" aria-hidden="true">&#9656;</span></button>
+                            <button type="button" class="nav-help-toggle" data-nav="help">Help <span class="nav-help-caret" aria-hidden="true">&#9656;</span></button>
                             <div class="nav-help-sub">
                                 <a href="/help-hosts.php">Host Guide</a>
                                 <a href="/help-guests.php">Guest Guide</a>
@@ -166,9 +166,9 @@ $_accent        = get_setting('accent_color', '');
              src="<?= htmlspecialchars($_banner) ?>?v=<?= $_banner_v ?>"
              alt="<?= htmlspecialchars($site_name) ?>"
              style="max-height:38px;width:auto"
-             onclick="toggleNavCollapse()" title="Toggle navigation">
+             data-nav="collapse" title="Toggle navigation">
         <?php else: ?>
-        <button class="nav-collapse-btn" id="navCollapseBtn" title="Toggle navigation" onclick="toggleNavCollapse()">&#x25B2;</button>
+        <button class="nav-collapse-btn" id="navCollapseBtn" title="Toggle navigation" data-nav="collapse">&#x25B2;</button>
         <?php endif; ?>
     </div>
     <div class="nav-links nav-collapsible">

--- a/www/_post_card.php
+++ b/www/_post_card.php
@@ -43,7 +43,7 @@ $redir = '/' . ($monthFilter ? '?month=' . urlencode($monthFilter) : '') . '#pos
                         ? '/admin_posts.php?edit=' . (int)$post['id']
                         : '/league.php?id=' . $__p_league_id . '&tab=posts&edit=' . (int)$post['id'] ?>">Edit</a>
                     <form method="post" action="<?= $__p_is_global ? '/admin_posts.php' : '/league_posts_dl.php' ?>" style="margin:0"
-                          onsubmit="return pkConfirmForm(this, 'Delete this post?', {okLabel:'Delete', danger:true})">
+                          data-confirm="Delete this post?" data-confirm-ok="Delete" data-confirm-danger="1">
                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                         <input type="hidden" name="action" value="delete">
                         <?php if ($__p_is_global): ?>
@@ -64,14 +64,14 @@ $redir = '/' . ($monthFilter ? '?month=' . urlencode($monthFilter) : '') . '#pos
 
     <!-- Comments -->
     <div class="comments-section" id="csec-<?= (int)$post['id'] ?>">
-        <div class="comments-heading" onclick="toggleComments(<?= (int)$post['id'] ?>)">
+        <div class="comments-heading" data-pc="toggle-comments" data-post="<?= (int)$post['id'] ?>">
             <span class="cmts-toggle-label">
                 <span class="cmts-chevron">&#9658;</span>
                 <?= count($comments) ?> Comment<?= count($comments) !== 1 ? 's' : '' ?>
             </span>
             <?php if ($isAdmin && count($comments) > 0): ?>
-            <label class="sel-all-label" onclick="event.stopPropagation()">
-                <input type="checkbox" class="sel-all" onchange="toggleSelAll(<?= (int)$post['id'] ?>, this)"> Select all
+            <label class="sel-all-label" data-pc="stop">
+                <input type="checkbox" class="sel-all" data-pc="sel-all" data-post="<?= (int)$post['id'] ?>"> Select all
             </label>
             <?php endif; ?>
         </div>
@@ -80,14 +80,14 @@ $redir = '/' . ($monthFilter ? '?month=' . urlencode($monthFilter) : '') . '#pos
             <div class="bulk-bar" id="bulk-<?= (int)$post['id'] ?>" style="display:none">
                 <span class="bulk-count" id="bulkcount-<?= (int)$post['id'] ?>">0 selected</span>
                 <form method="post" action="/comment.php" style="margin:0;display:contents"
-                      onsubmit="return prepareBulkDelete(<?= (int)$post['id'] ?>, this)">
+                      data-pc="bulk-delete" data-post="<?= (int)$post['id'] ?>">
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                     <input type="hidden" name="action" value="bulk_delete">
                     <input type="hidden" name="comment_ids" value="">
                     <input type="hidden" name="redirect" value="<?= htmlspecialchars($redir) ?>">
                     <button type="submit" class="btn btn-danger" style="font-size:.75rem;padding:.25rem .65rem">Delete selected</button>
                 </form>
-                <button type="button" onclick="clearSel(<?= (int)$post['id'] ?>)"
+                <button type="button" data-pc="clear-sel" data-post="<?= (int)$post['id'] ?>"
                         class="btn btn-outline" style="font-size:.75rem;padding:.25rem .65rem">Cancel</button>
             </div>
             <?php endif; ?>
@@ -96,7 +96,7 @@ $redir = '/' . ($monthFilter ? '?month=' . urlencode($monthFilter) : '') . '#pos
             <div class="comment" id="cmt-<?= (int)$c['id'] ?>">
                 <?php if ($isAdmin): ?>
                 <input type="checkbox" class="comment-sel" value="<?= (int)$c['id'] ?>"
-                       onchange="onSelChange(<?= (int)$post['id'] ?>)">
+                       data-pc="sel-change" data-post="<?= (int)$post['id'] ?>">
                 <?php endif; ?>
                 <?= avatar_html($c['username'], $c['avatar_path'] ?? null, 34) ?>
                 <div class="comment-content">
@@ -108,10 +108,10 @@ $redir = '/' . ($monthFilter ? '?month=' . urlencode($monthFilter) : '') . '#pos
                     <?php if ($user && ($user['id'] == $c['user_id'] || $isAdmin)): ?>
                     <div class="comment-actions">
                         <button type="button" class="comment-delete"
-                                onclick="editComment(<?= (int)$c['id'] ?>, this)"
+                                data-pc="edit-comment" data-comment="<?= (int)$c['id'] ?>"
                                 title="Edit">&#9998;</button>
                         <form method="post" action="/comment.php" style="margin:0;display:contents"
-                              onsubmit="return pkConfirmForm(this, 'Delete this comment?', {okLabel:'Delete', danger:true})">
+                              data-confirm="Delete this comment?" data-confirm-ok="Delete" data-confirm-danger="1">
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                             <input type="hidden" name="action" value="delete">
                             <input type="hidden" name="comment_id" value="<?= (int)$c['id'] ?>">

--- a/www/index.php
+++ b/www/index.php
@@ -788,6 +788,51 @@ endif; ?>
 </script>
 
 <script nonce="<?= csp_nonce() ?>">
+// ── Post-card event delegation ────────────────────────────────────────────
+// _post_card.php carries no inline on* handlers; it tags elements with data-pc
+// and data-confirm instead, and they are dispatched here. Delegation on
+// document is what makes this work for cards injected later by posts_chunk.php
+// as well as the ones rendered with the page. Step 2 of the CSP work in
+// SECURITY.md: inline handlers cannot be authorised by a nonce, so they have to
+// go before script-src-attr 'unsafe-inline' can be dropped.
+document.addEventListener('click', function (e) {
+    var t = e.target.closest('[data-pc]');
+    if (!t) return;
+    var post = parseInt(t.dataset.post, 10);
+    switch (t.dataset.pc) {
+        case 'toggle-comments': toggleComments(post); break;
+        case 'stop':            e.stopPropagation(); break;
+        case 'clear-sel':       clearSel(post); break;
+        case 'edit-comment':    editComment(parseInt(t.dataset.comment, 10), t); break;
+    }
+});
+
+document.addEventListener('change', function (e) {
+    var t = e.target.closest('[data-pc]');
+    if (!t) return;
+    var post = parseInt(t.dataset.post, 10);
+    if (t.dataset.pc === 'sel-all')    toggleSelAll(post, t);
+    if (t.dataset.pc === 'sel-change') onSelChange(post);
+});
+
+document.addEventListener('submit', function (e) {
+    var f = e.target;
+    if (f.dataset && f.dataset.pc === 'bulk-delete') {
+        if (prepareBulkDelete(parseInt(f.dataset.post, 10), f) === false) e.preventDefault();
+        return;
+    }
+    // Generic confirm-before-submit, replacing onsubmit="return pkConfirmForm(...)".
+    // pkConfirmForm() resolves the dialog and then calls formEl.submit(), which
+    // does NOT fire the submit event again, so this cannot recurse.
+    if (f.dataset && f.dataset.confirm) {
+        e.preventDefault();
+        pkConfirmForm(f, f.dataset.confirm, {
+            okLabel: f.dataset.confirmOk || 'OK',
+            danger:  f.dataset.confirmDanger === '1'
+        });
+    }
+});
+
 function toggleComments(postId) {
     const body = document.getElementById('cmts-body-' + postId);
     const hdr  = body.previousElementSibling;

--- a/www/nav.js
+++ b/www/nav.js
@@ -6,3 +6,31 @@ document.addEventListener('click', function(e) {
         });
     }
 });
+
+// ── Nav event delegation ─────────────────────────────────────────────────────
+// _nav.php carries no inline on* handlers; it tags controls with data-nav and
+// they are dispatched here. This file is external, so it is covered by
+// script-src 'self' and needs no nonce. Step 2 of the CSP work in SECURITY.md.
+//
+// Ordering note: this listener must run BEFORE the close-on-outside-click
+// handler above would otherwise undo it. It does not, because that one only
+// acts when the click is outside .nav-dropdown-wrap, and every control here is
+// inside one — except the collapse button, which owns no dropdown.
+document.addEventListener('click', function (e) {
+    var t = e.target.closest('[data-nav]');
+    if (!t) return;
+    switch (t.dataset.nav) {
+        case 'dropdown': {
+            // Toggle this control's own dropdown, the next sibling element.
+            var d = t.nextElementSibling;
+            if (d) d.style.display = (d.style.display === 'block') ? 'none' : 'block';
+            break;
+        }
+        case 'help':
+            t.parentElement.classList.toggle('open');
+            break;
+        case 'collapse':
+            if (typeof toggleNavCollapse === 'function') toggleNavCollapse();
+            break;
+    }
+});

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2072');
+define('APP_VERSION', '0.2073');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Security

**Inline event handlers removed from the nav and the post card.** This is step 2 of the CSP work: inline `on*` attributes cannot be authorized by a nonce, so they have to go before `script-src-attr 'unsafe-inline'` can be tightened.

`_nav.php` (7 handlers) and `_post_card.php` (9) are now at zero. Tree-wide: **579 → 564**. `checkin.php` (165) and `timer.php` (154) remain.

### The pattern this establishes

- Controls carry a `data-*` attribute holding whatever the old handler passed as arguments: `data-nav="dropdown"`, `data-pc="toggle-comments" data-post="12"`.
- Dispatch happens from a **delegated listener on `document`**, not per-element binding. That is a requirement rather than a preference here: `posts_chunk.php` injects further cards by AJAX after load, and per-element listeners would miss them.
- Prefer an existing **external** `.js` file as the destination. Nav dispatch went into `nav.js`, which needs no nonce because it is covered by `'self'`. Post-card dispatch sits in `index.php`'s nonced block, beside the functions it calls.
- `onsubmit="return pkConfirmForm(...)"` becomes a reusable `data-confirm` / `data-confirm-ok` / `data-confirm-danger` trio handled by one `submit` listener. It calls the existing `pkConfirmForm()`, which submits via `formEl.submit()` and therefore does not re-fire the listener, so it cannot recurse. I initially hand-rolled a re-submit guard for this and removed it once that was confirmed.

### Verification

11 assertions, 0 failures: no inline `on*` attributes remain in either file's rendered markup; the nav dropdown opens and closes; the help toggle flips its parent class; the collapse button reaches `toggleNavCollapse()`; the comments heading dispatches `toggleComments`; and a `data-confirm` form opens the confirm dialog **without navigating away**.

Worth recording: the first run reported 8/8 while **silently skipping** the two post-card checks, because every post on the test instance is league-scoped and the test account belonged to no league, so no cards rendered. The suite was green having verified nothing about `_post_card.php`. It now seeds a membership, an admin role and a comment first, and all 11 checks genuinely execute.

Regression suites green: 29 CSP nonce, 25 security smoke, 48 timer-fit, 10 gesture, plus both documented pre-push sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)