### PR TITLE
Fix nav dead after v0.2073: cache-bust nav.js (v0.2074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2074] - 2026-08-09
+
+### Fixed
+- **The nav stopped responding after v0.2073 for anyone with a cached `nav.js`.** v0.2073 moved the nav's click handling out of inline `onclick` attributes and into `nav.js`, but that was the one local script tag in the tree served without a cache-buster, so browsers kept the previous copy. The markup emitted `data-nav` attributes that the stale file knew nothing about and every nav control went dead: account menu, hamburger, Help toggle and the collapse arrow. `_nav.php` now versions it as `?v=APP_VERSION.mtime`, the same form `pk-seg.js`, `pk-dialogs.js` and `help-bubble.js` already used. `_phone_input.js` had the identical gap across 9 pages and is versioned too; no local script tag is left unbusted. This is the same failure mode as the stale-stylesheet fix in v0.2062: moving behaviour into an asset makes a stale copy a broken feature rather than merely an out-of-date one.
+
 ## [v0.2073] - 2026-08-09
 
 ### Security

--- a/www/_nav.php
+++ b/www/_nav.php
@@ -252,4 +252,7 @@ function toggleNavCollapse(){
     });
 })();
 </script>
-<script src="/nav.js" defer></script>
+<!-- Cache-busted like every other asset: nav.js now holds the delegated
+     handlers for data-nav controls, so a stale cached copy leaves the nav
+     dead rather than merely out of date. -->
+<script src="/nav.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/nav.js') ?: 0)) ?>" defer></script>

--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -3270,7 +3270,7 @@ function updatePreview() {
     if (accentEl) accentEl.style.color = /^#[0-9a-fA-F]{6}$/.test(acc)  ? acc  : '#2563eb';
 }
 </script>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/contact_edit.php
+++ b/www/contact_edit.php
@@ -113,7 +113,7 @@ $canMsg   = $isLinked && (int)$c['linked_user_id'] !== $uid;
     </div>
 </div>
 <?php require __DIR__ . '/_footer.php'; ?>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">
 initPhoneAutoFormat();
 var CSRF = <?= json_encode($csrf) ?>;

--- a/www/contacts.php
+++ b/www/contacts.php
@@ -228,7 +228,7 @@ function addContact() {
 </script>
 
 <?php require __DIR__ . '/_footer.php'; ?>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/league.php
+++ b/www/league.php
@@ -2103,7 +2103,7 @@ function escapeHtml(s) {
 </script>
 
 <?php require __DIR__ . '/_footer.php'; ?>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/register.php
+++ b/www/register.php
@@ -399,7 +399,7 @@ function syncNotify() {
 
 updateContactHint();
 </script>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 <script src="/pk-dialogs.js?v=<?= @filemtime(__DIR__ . '/pk-dialogs.js') ?>" defer></script>
 </body>

--- a/www/register_dl.php
+++ b/www/register_dl.php
@@ -199,7 +199,7 @@ document.querySelectorAll('button[aria-label="Show password"], button[aria-label
     btn.addEventListener('touchend', toggle);
 });
 </script>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/settings.php
+++ b/www/settings.php
@@ -572,7 +572,7 @@ $site_name = get_setting('site_name', 'Game Night');
 </div>
 
 <?php require __DIR__ . '/_footer.php'; ?>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/user_edit.php
+++ b/www/user_edit.php
@@ -350,7 +350,7 @@ $site_name = get_setting('site_name', 'Game Night');
 </div>
 
 <?php require __DIR__ . '/_footer.php'; ?>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2073');
+define('APP_VERSION', '0.2074');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and

--- a/www/walkin.php
+++ b/www/walkin.php
@@ -500,7 +500,7 @@ $csrf_token = csrf_token();
         <?php endif; ?>
     </div>
 </div>
-<script src="/_phone_input.js"></script>
+<script src="/_phone_input.js?v=<?= htmlspecialchars(APP_VERSION . '.' . (@filemtime(__DIR__ . '/_phone_input.js') ?: 0)) ?>"></script>
 <script nonce="<?= csp_nonce() ?>">initPhoneAutoFormat();</script>
 </body>
 </html>


### PR DESCRIPTION
### Fixed

**The nav stopped responding after v0.2073 for anyone with a cached `nav.js`.**

v0.2073 moved the nav's click handling out of inline `onclick` attributes and into `nav.js`. That was the one local script tag in the tree served without a cache-buster:

```php
<script src="/nav.js" defer></script>                       ← no version
<script src="/pk-seg.js?v=<?= APP_VERSION . '.' . mtime ?>" ← every other one
```

So browsers kept the previous copy. The markup emitted `data-nav` attributes the stale file knew nothing about, and every nav control went dead: account menu, hamburger, Help toggle, collapse arrow.

`_nav.php` now versions it as `?v=APP_VERSION.mtime`, the same form `pk-seg.js`, `pk-dialogs.js` and `help-bubble.js` already used. `_phone_input.js` had the identical gap across 9 pages and is versioned too. No local script tag is left unbusted.

This is the same failure mode as the stale-stylesheet fix in v0.2062. The lesson generalises: moving behaviour into an asset turns a stale cached copy from an out-of-date file into a broken feature, so an asset that gains behaviour needs a cache-buster in the same change.

### Verification

Three assertions. The middle one is the diagnosis, and the third proves it rather than assuming it:

- `nav.js` tag now carries a version query, and `_phone_input.js` does too.
- The nav dropdown opens, so the delegation is live.
- **With the old `nav.js` forced back in via request interception, the dropdown stays shut** — reproducing the reported failure exactly, and confirming the cache-buster is what fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)