### PR TITLE
Security: CSP blocks injected script outright (v0.2079)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2079] - 2026-08-10
+
+### Security
+- **CSP now blocks injected script outright, closing the gap the v0.2070 review opened with.** `script-src` and `script-src-elem` carry the per-request nonce and `script-src-attr` is `'none'`, so an injected `<script>` is refused because it cannot carry the nonce, and an injected `on*` attribute is refused because attribute handlers are disallowed. Until now the policy allowed `'unsafe-inline'`, which meant the browser could not tell the app's own inline code from an attacker's and every XSS finding in that review would have executed unimpeded. The nonce is carried on `script-src` as well as `script-src-elem` deliberately: browsers without CSP3 granularity fall back to `script-src`, and a nonce there makes `'unsafe-inline'` ignored, so they get the same guarantee rather than none. This was only possible because all 401 inline handlers became delegated listeners over v0.2073-v0.2078. Pre-flight before switching: a DOM scan across 36 pages found zero `on*` attributes in rendered markup, including JS-built, and zero unnonced inline `<script>` blocks. After switching: an injected handler and an injected nonce-less script are both confirmed blocked, every nonced inline block still runs, and 431 controls across 37 pages still fire exactly once. Anything added from here must use the `data-act*` pattern in `SECURITY.md`, because an inline handler will now simply not fire.
+
 ## [v0.2078] - 2026-08-10
 
 ### Fixed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ Working notes for this codebase: the checks to run before shipping, and the one
 known hardening gap that has not been closed yet. Kept in the repo so neither
 gets lost between sessions.
 
-Last reviewed: 2026-08-10 (v0.2078).
+Last reviewed: 2026-08-10 (v0.2079).
 
 ---
 
@@ -99,13 +99,26 @@ exists.
 
 ---
 
-## Known gap: CSP allows `script-src 'unsafe-inline'`
+## CLOSED: CSP no longer allows inline script (v0.2079)
 
-`auth.php` sets:
+`auth.php` now sets:
 
 ```
-script-src 'self' 'unsafe-inline'
+script-src       'self' 'nonce-<per-request>'
+script-src-elem  'self' 'nonce-<per-request>'
+script-src-attr  'none'
 ```
+
+An injected `<script>` is refused because it cannot carry the nonce, and an
+injected `on*` attribute is refused because attribute handlers are disallowed
+outright. **CSP is now a real second line of defence against XSS**, which it was
+not for any of the findings in the v0.2070 review.
+
+The nonce is carried on `script-src` as well as `script-src-elem` deliberately:
+browsers without CSP3 granularity fall back to `script-src`, and a nonce there
+makes `'unsafe-inline'` ignored, so they get the same guarantee rather than none.
+
+### How it used to read, and why it took six releases
 
 `'self'` stops an attacker loading script from another origin. `'unsafe-inline'`
 additionally permits script written inside the HTML, covering both `<script>`
@@ -246,11 +259,17 @@ which is exactly the pattern that has to move to event delegation.
    - Verify with the **old** asset forced back in (Playwright `page.route()` can
      serve the previous file) to prove the cache-buster is what fixes it, rather
      than assuming.
-3. **Drop `script-src-attr 'unsafe-inline'`.** Now unblocked: the count reached
-   zero in v0.2078. Run `Content-Security-Policy-Report-Only` with the tighter
-   value for a while first to catch anything that re-introduces an inline
-   handler, then switch it live. At that point CSP finally blocks an injected
-   `on*` attribute, which is the half of the XSS surface still open.
+3. ~~**Drop `script-src-attr 'unsafe-inline'`.**~~ **DONE in v0.2079.** Verified
+   before switching: a DOM scan across 36 pages found zero `on*` attributes in
+   rendered markup (including JS-built) and zero unnonced inline `<script>`
+   blocks. After switching, an injected `on*` handler and an injected
+   nonce-less `<script>` are both confirmed blocked, while every nonced inline
+   block still runs.
+
+**Anything added from here must follow the conversion pattern below**, because
+an inline handler will now simply not fire. `pk-dispatch.js` logs
+`[pk-dispatch] no handler named X` when a name does not resolve, and the sweeps
+in the pre-push section catch the rest.
 
 Until then, the sweeps above are the compensating control. They are the
 difference between catching a regression in two seconds and catching it in a

--- a/www/auth.php
+++ b/www/auth.php
@@ -22,21 +22,27 @@ try {
 // Per-request nonce for inline <script> blocks. See SECURITY.md.
 // Why three script directives instead of one:
 //   script-src       fallback for browsers without CSP3 granularity (Firefox).
-//                    Keeps 'unsafe-inline' so behaviour there is unchanged.
+//                    Carries the nonce, so 'unsafe-inline' is ignored there too
+//                    and inline handlers are refused, same as everywhere else.
 //   script-src-elem  script ELEMENTS must carry this nonce. Adding a nonce makes
 //                    a browser ignore 'unsafe-inline', so an injected <script> is
 //                    refused — which is the point.
-//   script-src-attr  event handler ATTRIBUTES stay allowed for now. They cannot
-//                    be nonced (there is no syntax for it), so until the ~579
-//                    inline on* handlers become addEventListener they need their
-//                    own directive or every button on the site stops working.
+//   script-src-attr  'none'. Event handler attributes cannot be nonced (there is
+//                    no syntax for it), so the only way to allow them is
+//                    'unsafe-inline' — which is what made CSP useless against
+//                    XSS. All 401 of them became delegated listeners over
+//                    v0.2073-v0.2078, so this can now be shut.
 if (!defined('CSP_NONCE')) define('CSP_NONCE', base64_encode(random_bytes(16)));
 
 $_csp = implode('; ', [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
+    // The tree has no inline on* handlers left (v0.2078), so the browser can now
+    // refuse them outright. Carrying the nonce on script-src as well is what
+    // protects browsers with no CSP3 granularity: a nonce makes 'unsafe-inline'
+    // ignored there too, so they get the same guarantee rather than none.
+    "script-src 'self' 'nonce-" . CSP_NONCE . "'",
     "script-src-elem 'self' 'nonce-" . CSP_NONCE . "'",
-    "script-src-attr 'unsafe-inline'",
+    "script-src-attr 'none'",
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: https://*.ytimg.com https://*.twitch.tv https://*.jtvnw.net",
     "object-src 'none'",

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2078');
+define('APP_VERSION', '0.2079');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Security

**CSP now blocks injected script outright, closing the gap the v0.2070 review opened with.**

```
script-src       'self' 'nonce-<per-request>'
script-src-elem  'self' 'nonce-<per-request>'
script-src-attr  'none'
```

An injected `<script>` is refused because it cannot carry the nonce. An injected `on*` attribute is refused because attribute handlers are disallowed outright.

Until now the policy allowed `'unsafe-inline'`, which meant the browser could not distinguish the app's own inline code from an attacker's, so **every XSS finding in the v0.2070 review would have executed unimpeded**. CSP was decorative. It is now a real second line of defence: a future escaping slip produces an injection the browser refuses to run.

The nonce is carried on `script-src` as well as `script-src-elem` deliberately. Browsers without CSP3 granularity fall back to `script-src`, and a nonce there makes `'unsafe-inline'` ignored, so they get the same guarantee rather than none.

This was only possible because all **401** inline handlers became delegated listeners over v0.2073–v0.2078.

### Pre-flight, before switching

Two conditions had to hold, and the source having zero handlers does not prove either — rendered markup is what the browser sees:

- **Zero `on*` attributes in the rendered DOM** across 36 pages, including markup built at runtime by JS.
- **Zero inline `<script>` without a nonce**, since adding a nonce to `script-src` makes `'unsafe-inline'` ignored there too and an unnonced block would stop running.

Both were clean.

### After switching

| Check | Result |
|---|---|
| Injected `on*` handler | **blocked** |
| Injected nonce-less `<script>` | **blocked** |
| Nonced inline blocks still execute (timer, checkin globals) | yes |
| CSP violations across 9 heavy pages | none |
| Double-dispatch sweep, 431 controls / 37 pages | all fire exactly once |
| checkin 294, timer 954, pages 171 dispatches | 0 wrong |
| Security smoke 25, CSP suite 29, lint + escaping sweeps | clean |

Three assertions in the CSP suite were inverted as part of this, because they encoded the old intent — most notably "inline `on*` handlers still execute", which is now precisely what must fail.

### From here

Anything added must use the `data-act*` pattern documented in `SECURITY.md`: an inline handler will now simply not fire. `pk-dispatch.js` logs `[pk-dispatch] no handler named X` when a name does not resolve, and the three pre-push sweeps catch the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)