### PR TITLE
Stop Jodit fetching js-beautify and ACE from cdnjs (v0.2080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2080] - 2026-08-10
+
+### Fixed
+- **The rich-text editor stopped making two blocked cross-origin requests on every page that carries one.** Jodit fetches `js-beautify` and ACE from cdnjs when it initialises, not on demand, and `script-src 'self'` has refused both since long before the CSP work — so the source-view highlighting and HTML beautifying were never actually functioning here, they were just failing noisily. `beautifyHTML: false` and `sourceEditor: 'area'` are now set on all four editors (`admin_posts.php`, `calendar.php`, `event.php`, `league.php`), which stops the requests and the console errors. Source view still opens, as a plain textarea without syntax highlighting. Hosting both libraries locally would restore those features and remains an option; disabling them was chosen because the app has run without them for the life of the CSP and neither is load-bearing.
+
 ## [v0.2079] - 2026-08-10
 
 ### Security

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -481,6 +481,12 @@ const csrfToken = <?= json_encode($token) ?>;
 let editor = null;
 document.addEventListener('DOMContentLoaded', function () {
 editor = Jodit.make('#jodit-editor', {
+    // Jodit pulls js-beautify and ACE from cdnjs on load. script-src is 'self',
+    // so both are refused and the features never worked here — this just stops
+    // two dead cross-origin requests and the console noise on every page with an
+    // editor. Source view still opens, as a plain textarea without highlighting.
+    beautifyHTML: false,
+    sourceEditor: 'area',
     height: 420,
     toolbarButtonSize: 'middle',
     buttons: [

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -3232,6 +3232,12 @@ let _emEditor = null;
 function _emEnsureEditor() {
     if (_emEditor || typeof Jodit === 'undefined') return;
     _emEditor = Jodit.make('#emBody', {
+        // Jodit pulls js-beautify and ACE from cdnjs on load. script-src is 'self',
+        // so both are refused and the features never worked here — this just stops
+        // two dead cross-origin requests and the console noise on every page with an
+        // editor. Source view still opens, as a plain textarea without highlighting.
+        beautifyHTML: false,
+        sourceEditor: 'area',
         height: 280,
         toolbarAdaptive: false,
         buttons: ['bold','italic','underline','|','ul','ol','|','link','|','paragraph','align','|','undo','redo'],

--- a/www/event.php
+++ b/www/event.php
@@ -845,6 +845,12 @@ var _emEditor = null;
 function _emEnsureEditor() {
     if (_emEditor || typeof Jodit === 'undefined') return;
     _emEditor = Jodit.make('#emBody', {
+        // Jodit pulls js-beautify and ACE from cdnjs on load. script-src is 'self',
+        // so both are refused and the features never worked here — this just stops
+        // two dead cross-origin requests and the console noise on every page with an
+        // editor. Source view still opens, as a plain textarea without highlighting.
+        beautifyHTML: false,
+        sourceEditor: 'area',
         height: 280, toolbarAdaptive: false,
         buttons: ['bold','italic','underline','|','ul','ol','|','link','|','paragraph','align','|','undo','redo'],
         uploader: { insertImageAsBase64URI: true },

--- a/www/league.php
+++ b/www/league.php
@@ -1315,6 +1315,12 @@ function ordinal($n) {
                 if (_joditReady || typeof Jodit === 'undefined') return;
                 _joditReady = true;
                 Jodit.make('#lp-editor', {
+                    // Jodit pulls js-beautify and ACE from cdnjs on load. script-src is 'self',
+                    // so both are refused and the features never worked here — this just stops
+                    // two dead cross-origin requests and the console noise on every page with an
+                    // editor. Source view still opens, as a plain textarea without highlighting.
+                    beautifyHTML: false,
+                    sourceEditor: 'area',
                     height: 340,
                     toolbarAdaptive: false,
                     buttons: ['bold','italic','underline','|','ul','ol','|','outdent','indent','|','link','image','|','hr','brush','|','source','|','undo','redo'],

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2079');
+define('APP_VERSION', '0.2080');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Fixed

**The rich-text editor stopped making two blocked cross-origin requests on every page that carries one.**

Jodit fetches `js-beautify` and ACE from cdnjs **when it initialises**, not on demand — I confirmed both are requested on page load, before any source-view interaction. `script-src 'self'` has refused both since long before the CSP work, so the source-view syntax highlighting and HTML beautifying were never actually functioning here. They were failing noisily.

`beautifyHTML: false` and `sourceEditor: 'area'` are now set on all four editors: `admin_posts.php`, `calendar.php`, `event.php`, `league.php`. Source view still opens, as a plain textarea without highlighting.

Hosting both libraries locally (via `docker-entrypoint.sh`, as Jodit itself already is) would restore the features and remains a straightforward option. Disabling was chosen because the app has run without them for the life of the CSP, neither is load-bearing, and it removes two third-party fetches from every editor page rather than adding two more vendored dependencies.

### Verification

| Check | Result |
|---|---|
| CDN requests on all 4 editor pages | **none** (was 2 per page) |
| CSP load violations | **none** |
| Editor initialises and accepts content | yes |
| Options actually applied (`beautifyHTML:false`, `sourceEditor:'area'`) | yes |
| Toolbar renders | yes |

11 assertions, 0 failures. Recursive `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)