### PR TITLE
Security: stop the invite backfill undoing the v0.2070 authz fix (v0.2081)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2081] - 2026-08-10
+
+### Security
+- **The event-authorization fix from v0.2070 was being undone on every request.** That release moved event visibility and co-host authority off the free-text `event_invites.username` and onto a new `user_id` column, and added a backfill to populate it from the existing username match. The backfill was written as one-time but was not guarded, and `db_init()` runs on **every** request, so it kept re-materialising the very link that had just been removed from `can_manage_event()` and `event_visibility_sql()`. An attacker who registered a username matching an unlinked invite had their account id written into that row on their next page load, inheriting the invite's private-event visibility and, on a co-host row, full host control. Verified end to end before and after the fix. The backfill is now one-shot behind a `site_settings` flag, matching the `api_keys` prune pattern already in `db_init()`. Because it was load-bearing — several insert paths never populated `user_id` at all and relied on it — all eight `INSERT INTO event_invites` sites now resolve the link at write time via a new `resolve_invite_user_id()` helper, or use the acting user's id for self-signup. That is the correct semantics: linking is the host's decision about someone who already has an account, never something a stranger can trigger later by claiming a name. Production audit at the time of the fix: 178 unlinked invite rows, 62 with claimable usernames, **zero co-host**, so the reachable impact was private-event disclosure rather than host takeover; and of the 25 links the unguarded backfill had created retroactively, all were ordinary invitees registering hours after their invite, with no sign of exploitation.
+
 ## [v0.2080] - 2026-08-10
 
 ### Fixed

--- a/www/_poker_helpers.php
+++ b/www/_poker_helpers.php
@@ -689,9 +689,9 @@ function pk_ticket_ensure_invite($db, int $target_event_id, ?int $user_id, strin
             $s->execute([$source_event_id, $display_name]);
             if ($sr = $s->fetch()) { $phone = $sr['phone'] ?: null; $email = $sr['email'] ?: null; }
         }
-        $db->prepare("INSERT INTO event_invites (event_id, username, phone, email, rsvp, event_role, approval_status)
-                      VALUES (?, ?, ?, ?, 'yes', 'invitee', 'approved')")
-           ->execute([$target_event_id, $username, $phone, $email]);
+        $db->prepare("INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, event_role, approval_status)
+                      VALUES (?, ?, ?, ?, ?, 'yes', 'invitee', 'approved')")
+           ->execute([$target_event_id, $username, resolve_invite_user_id($db, $username), $phone, $email]);
     } catch (Exception $e) { /* invite is best-effort; the ticket itself is the record */ }
 }
 

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -309,8 +309,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $baseStmt->execute([$eid, $target_username]);
                     $baseRow = $baseStmt->fetch();
                     $baseApproval = $on_behalf ? 'approved' : ($baseRow['approval_status'] ?? 'approved');
-                    $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, rsvp_token, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
-                       ->execute([$eid, canonical_username($target_username), $baseRow['phone'] ?? null, $baseRow['email'] ?? null, $rsvp, bin2hex(random_bytes(16)), $occDate, $baseApproval]);
+                    $db->prepare('INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, rsvp_token, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
+                       ->execute([$eid, canonical_username($target_username), $baseRow['user_id'] ?? resolve_invite_user_id($db, $target_username), $baseRow['phone'] ?? null, $baseRow['email'] ?? null, $rsvp, bin2hex(random_bytes(16)), $occDate, $baseApproval]);
                 }
             } else {
                 // Base RSVP (non-recurring or updating all-occurrence default)
@@ -374,8 +374,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!$existing_signup) {
                 // Self-signup: approval gate fires if the event has requires_approval=1.
                 $approval = invite_approval_status($eid, 'self');
-                $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, rsvp_token, approval_status) VALUES (?, ?, ?, ?, NULL, ?, ?)')
-                   ->execute([$eid, $current['username'], $udata['phone'] ?? null, $udata['email'] ?? null, bin2hex(random_bytes(16)), $approval]);
+                $db->prepare('INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, rsvp_token, approval_status) VALUES (?, ?, ?, ?, ?, NULL, ?, ?)')
+                   ->execute([$eid, $current['username'], (int)$current['id'], $udata['phone'] ?? null, $udata['email'] ?? null, bin2hex(random_bytes(16)), $approval]);
                 db_log_activity($current['id'], "signed up for event id: $eid" . ($approval === 'pending' ? ' (pending approval)' : ''));
                 if ($approval === 'pending') {
                     $signup_pending = true;

--- a/www/calendar_dl.php
+++ b/www/calendar_dl.php
@@ -179,8 +179,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     $base_stmt2->execute([$eid, $current['username']]);
                     $base_row2 = $base_stmt2->fetch() ?: [];
                     $base_approval2 = $base_row2['approval_status'] ?? 'approved';
-                    $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?)')
-                       ->execute([$eid, $current['username'], $base_row2['phone'] ?? null, $base_row2['email'] ?? null, $rsvp, $occ_date, $base_approval2]);
+                    $db->prepare('INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, occurrence_date, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+                       ->execute([$eid, $current['username'], (int)$current['id'], $base_row2['phone'] ?? null, $base_row2['email'] ?? null, $rsvp, $occ_date, $base_approval2]);
                 }
             } else {
                 // Non-recurring: update base row
@@ -233,8 +233,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!$existing_signup) {
                 // Self-signup: approval gate fires if the event has requires_approval=1.
                 $approval = invite_approval_status($eid, 'self');
-                $db->prepare('INSERT INTO event_invites (event_id, username, phone, email, rsvp, approval_status) VALUES (?, ?, ?, ?, NULL, ?)')
-                   ->execute([$eid, $current['username'], $udata['phone'] ?? null, $udata['email'] ?? null, $approval]);
+                $db->prepare('INSERT INTO event_invites (event_id, username, user_id, phone, email, rsvp, approval_status) VALUES (?, ?, ?, ?, ?, NULL, ?)')
+                   ->execute([$eid, $current['username'], (int)$current['id'], $udata['phone'] ?? null, $udata['email'] ?? null, $approval]);
                 db_log_activity($current['id'], "signed up for event id: $eid" . ($approval === 'pending' ? ' (pending approval)' : ''));
                 if ($approval === 'pending') {
                     $signup_pending = true;

--- a/www/checkin_dl.php
+++ b/www/checkin_dl.php
@@ -1152,8 +1152,8 @@ if ($action === 'add_walkin') {
     $eiChk = $db->prepare('SELECT id FROM event_invites WHERE event_id = ? AND LOWER(username) = LOWER(?) AND occurrence_date IS NULL');
     $eiChk->execute([$s['event_id'], $name]);
     if (!$eiChk->fetch()) {
-        $db->prepare("INSERT INTO event_invites (event_id, username, email, rsvp, approval_status) VALUES (?, ?, ?, 'yes', 'approved')")
-           ->execute([$s['event_id'], $existingUser['username'] ?? trim($name), $existingUser['email'] ?? null]);
+        $db->prepare("INSERT INTO event_invites (event_id, username, user_id, email, rsvp, approval_status) VALUES (?, ?, ?, ?, 'yes', 'approved')")
+           ->execute([$s['event_id'], $existingUser['username'] ?? trim($name), $user_id, $existingUser['email'] ?? null]);
     } else {
         // If they were pending/denied, approve them since the host is adding them manually.
         $db->prepare("UPDATE event_invites SET rsvp = 'yes', approval_status = 'approved' WHERE event_id = ? AND LOWER(username) = LOWER(?) AND occurrence_date IS NULL")

--- a/www/db.php
+++ b/www/db.php
@@ -1567,14 +1567,27 @@ JSON;
     // column instead. NULL means "not a known account", which grants nothing.
     try { $pdo->exec("ALTER TABLE event_invites ADD COLUMN user_id INTEGER"); } catch (Exception $e) {}
     try { $pdo->exec("CREATE INDEX IF NOT EXISTS idx_event_invites_user ON event_invites(user_id)"); } catch (Exception $e) {}
-    // One-time backfill from the existing username match. This only records the
-    // access people already had; it grants nothing new. Rows that match no
-    // account stay NULL and stop conferring anything, which is the fix.
+    // ONE-SHOT backfill, guarded by a site_setting flag exactly like the api_keys
+    // prune above. This ran unguarded in v0.2070-v0.2080 and db_init() executes on
+    // every request, so it kept re-materialising the username->account link that
+    // was just removed from can_manage_event() and event_visibility_sql(): an
+    // attacker who registered a name matching an unlinked invite had their id
+    // written into that row on their very next page load, inheriting its
+    // visibility and, on a co-host row, full host control. The read path was
+    // fixed and a writer was left recreating the hole.
+    //
+    // It must stay one-shot. Linking is the HOST's decision, made when they add
+    // someone who already has an account (see the INSERT sites, which now all
+    // resolve user_id at write time). It must never happen later because a
+    // stranger claimed the name.
     try {
-        $pdo->exec("UPDATE event_invites
-                       SET user_id = (SELECT u.id FROM users u
-                                       WHERE LOWER(u.username) = LOWER(event_invites.username))
-                     WHERE user_id IS NULL");
+        if (get_setting('event_invites_user_id_backfilled', '') !== '1') {
+            $pdo->exec("UPDATE event_invites
+                           SET user_id = (SELECT u.id FROM users u
+                                           WHERE LOWER(u.username) = LOWER(event_invites.username))
+                         WHERE user_id IS NULL");
+            set_setting('event_invites_user_id_backfilled', '1');
+        }
     } catch (Exception $e) {}
 
     // ─── Public league landing pages (/league/<slug>) ───────────────────
@@ -2458,6 +2471,27 @@ function normalize_phone(string $phone): string {
 // Resolve a typed username to the registered user's chosen case, so invitee
 // names render the way the user spelled their own name when they registered.
 // Falls back to the trimmed input for ad-hoc invitees who never registered.
+/**
+ * Resolve an invite's owning account AT WRITE TIME.
+ *
+ * event_invites.user_id is what confers event visibility and co-host authority
+ * (see can_manage_event() and event_visibility_sql()). Linking must therefore
+ * happen when the host adds the invite — that is the host's decision about a
+ * person who already has an account. It must NEVER happen later, because then
+ * anyone who registers a matching username inherits the invite. A backfill that
+ * ran on every request did exactly that between v0.2070 and v0.2080.
+ *
+ * Returns null when no account matches, and a null user_id grants nothing.
+ */
+function resolve_invite_user_id(PDO $db, ?string $username): ?int {
+    $username = trim((string)$username);
+    if ($username === '') return null;
+    $st = $db->prepare('SELECT id FROM users WHERE LOWER(username) = LOWER(?) LIMIT 1');
+    $st->execute([$username]);
+    $id = $st->fetchColumn();
+    return $id !== false ? (int)$id : null;
+}
+
 function canonical_username(string $typed): string {
     $typed = trim($typed);
     if ($typed === '') return '';

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2080');
+define('APP_VERSION', '0.2081');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and

--- a/www/walkin.php
+++ b/www/walkin.php
@@ -154,8 +154,8 @@ if (!$invalid && $_SERVER['REQUEST_METHOD'] === 'POST') {
                     // host sees a pending row and can approve or deny. For brand-new walk-in users
                     // (the main `else` block far below) we still honor the event's requires_approval
                     // setting because those identifiers don't belong to anyone yet.
-                    $db->prepare("INSERT INTO event_invites (event_id, username, email, rsvp, approval_status) VALUES (?, ?, ?, ?, 'pending')")
-                       ->execute([$event_id, $username, $email]);
+                    $db->prepare("INSERT INTO event_invites (event_id, username, user_id, email, rsvp, approval_status) VALUES (?, ?, ?, ?, ?, 'pending')")
+                       ->execute([$event_id, $username, resolve_invite_user_id($db, $username), $email]);
                     $effective_approval = 'pending';
                     $is_new_pending = true;
                 }
@@ -243,8 +243,8 @@ if (!$invalid && $_SERVER['REQUEST_METHOD'] === 'POST') {
 
                     // Invite to event. Walk-in is a 'self' signup — approval gate fires if requires_approval=1.
                     $new_walkin_approval = invite_approval_status($event_id, 'self');
-                    $db->prepare('INSERT INTO event_invites (event_id, username, email, phone, rsvp, approval_status) VALUES (?, ?, ?, ?, ?, ?)')
-                       ->execute([$event_id, $final_username, $has_email ? $email : null, $has_phone ? $phone_normalized : null, 'yes', $new_walkin_approval]);
+                    $db->prepare('INSERT INTO event_invites (event_id, username, user_id, email, phone, rsvp, approval_status) VALUES (?, ?, ?, ?, ?, ?, ?)')
+                       ->execute([$event_id, $final_username, $new_id, $has_email ? $email : null, $has_phone ? $phone_normalized : null, 'yes', $new_walkin_approval]);
 
                     auto_add_to_league($db, $event_id, $new_id);
                     db_log_anon_activity("walkin_new_user: $final_username for event $event_id" . ($new_walkin_approval === 'pending' ? ' (waiting list)' : ''));


### PR DESCRIPTION
### Security

**The event-authorization fix from v0.2070 was being undone on every request.**

That release moved event visibility and co-host authority off the free-text `event_invites.username` and onto a new `user_id` column, and added a backfill to populate it from the existing username match. The backfill was *described* as one-time but was **not guarded**, and `db_init()` runs on every request — so it kept re-materialising the exact link that had just been removed from `can_manage_event()` and `event_visibility_sql()`.

The read path was fixed and a writer was left recreating the hole.

**Exploit, verified end to end on a copy of the data:**

1. A host adds an invitee by typing a name (`dave`), who has no account. `user_id` is NULL.
2. The attacker registers the username `dave` — permitted, since `^[a-zA-Z0-9_]{3,30}$` covers ordinary first names.
3. On the attacker's **next page load**, `db_init()` writes their id into that invite row.
4. `can_manage_event()` returns true on a co-host row (full host control, including every invitee's email and phone); otherwise `event_visibility_sql()` grants access to the private event.

Before the fix: `user_id NULL → 309`, `can_manage_event() GRANTED`. After: `user_id` stays NULL across repeated loads, `can_manage_event()` denied, event not visible.

### Fix

- The backfill is **one-shot**, behind a `site_settings` flag, matching the `api_keys` prune pattern already in `db_init()`.
- It was load-bearing — several insert paths never populated `user_id` and depended on it — so **all eight** `INSERT INTO event_invites` sites now resolve the link at write time, via a new `resolve_invite_user_id()` helper or the acting user's id for self-signup.

That is the correct semantics: linking is the **host's** decision about someone who already has an account, and can never be triggered later by a stranger claiming a name.

### Production exposure at the time of the fix

| | |
|---|---|
| Unlinked invite rows | 178 |
| With claimable usernames | 62 |
| **Co-host rows among those** | **0** |

So the reachable impact was private-event disclosure, not host takeover — because the six claimable co-host rows were demoted during the v0.2070 work. Of the 25 links the unguarded backfill had created retroactively, all were ordinary invitees registering hours after their invite, with no sign of exploitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)