### PR TITLE
Fix the defects the inline-handler conversion left behind (v0.2082)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2082] - 2026-08-10
+
+### Fixed
+- **Cleaned up the defects the inline-handler conversion left behind.** Converting 401 inline `on*` attributes to declarative `data-act` markup across v0.2074-0.2079 broke a handful of controls in ways that were invisible to a lint pass, and the second security review surfaced them. `index.php` kept its own document-level `submit` listener for `data-confirm` while also receiving the shared `pk-dispatch.js`, so deleting a post or comment raised two stacked confirm dialogs — the same double-dispatch class that v0.2078 fixed for `checkin.php`; the duplicate listener is gone and the shared dispatcher owns the behaviour. The Start button on `messages.php` navigated to `message_thread.php?with=` while that page reads `?user=`. `data-href` in `pk-dispatch.js` ignored `data-stop`, so the Message button inside a contacts row navigated to the row's edit page instead; it now honours the boundary exactly as `data-act` does. `event_polls.php` had a PHP tag HTML-escaped into a confirm message and a JS concatenation emitted literally into the + Option button, `leagues.php` passed a `json_encode()` result into an attribute so the modal showed quoted text, and `timer.php` handed `loadPresetTheme`/`deletePresetTheme` a JSON-quoted preset key. Sixteen attributes across ten files carried a stray duplicated closing quote such as `data-confirm-danger="1""`.
+- **A confirmation dialog could silently disappear on invalid UTF-8.** The converted `data-confirm` attributes build their text with `htmlspecialchars(..., ENT_QUOTES)`, which returns an empty string when the input contains an invalid UTF-8 byte — so an event or username carrying one produced an empty `data-confirm` and the delete confirmation just did not appear. All such call sites now pass `ENT_QUOTES | ENT_SUBSTITUTE`. This is a client-side guard only; the underlying POST remains CSRF-protected and server-authorised either way.
+
+### Infrastructure
+- **The double-dispatch sweep now covers the generic behaviours and checks its own coverage.** `double_dispatch_sweep.js` only counted named `data-act*` functions, which is why it passed a release with the `index.php` double-confirm in it — `data-confirm` names no function, so there was nothing to count. It now stubs `pkConfirmForm()` and asserts exactly one call per `data-confirm` form and button, and flags any `data-*` attribute still containing an unresolved `<?= ?>` or a stray JS concatenation. Separately, the sweep had been running as a non-admin the whole time, so every admin page returned 403 and reported zero controls; it now fails loudly if the admin pages are unreachable and prints the promote/demote commands. Real coverage went from 262 to 558 controls.
+
 ## [v0.2081] - 2026-08-10
 
 ### Security

--- a/www/_nav.php
+++ b/www/_nav.php
@@ -60,9 +60,9 @@ $_accent        = get_setting('accent_color', '');
 <?php if ($_nav_bg || $_nav_text || $_accent || $_header_banner || $_banner): ?>
 <style>
 .nav-collapse-banner{max-height:38px;width:auto}
-<?php if ($_accent): ?>:root{--accent:<?= htmlspecialchars($_accent,ENT_QUOTES) ?>;--accent-h:<?= htmlspecialchars($_accent,ENT_QUOTES) ?>;}<?php endif; ?>
-<?php if ($_nav_bg): ?>nav{background:<?= htmlspecialchars($_nav_bg,ENT_QUOTES) ?> !important;}<?php endif; ?>
-<?php if ($_nav_text): ?>nav .brand,nav .brand:hover{color:<?= htmlspecialchars($_nav_text,ENT_QUOTES) ?> !important;}<?php endif; ?>
+<?php if ($_accent): ?>:root{--accent:<?= htmlspecialchars($_accent, ENT_QUOTES | ENT_SUBSTITUTE) ?>;--accent-h:<?= htmlspecialchars($_accent, ENT_QUOTES | ENT_SUBSTITUTE) ?>;}<?php endif; ?>
+<?php if ($_nav_bg): ?>nav{background:<?= htmlspecialchars($_nav_bg, ENT_QUOTES | ENT_SUBSTITUTE) ?> !important;}<?php endif; ?>
+<?php if ($_nav_text): ?>nav .brand,nav .brand:hover{color:<?= htmlspecialchars($_nav_text, ENT_QUOTES | ENT_SUBSTITUTE) ?> !important;}<?php endif; ?>
 <?php if ($_header_banner && !$_is_mobile): ?>
 .nav-top{height:<?= $_header_banner_height ?>px !important;align-items:flex-start !important;padding-top:8px !important;}
 <?php endif; ?>
@@ -125,7 +125,7 @@ $_accent        = get_setting('accent_color', '');
                         <a href="/admin_posts.php" class="nav-mobile-link<?= $_active === 'posts' ? ' active' : '' ?>">Posts</a>
                         <a href="/admin_settings.php" class="nav-mobile-link<?= $_active === 'site-settings' ? ' active' : '' ?>">Site Settings<?php if ($_show_update_dot): ?> <span class="nav-update-dot" title="Update available: v<?= htmlspecialchars(get_setting('latest_version')) ?>"></span><?php endif; ?></a>
                         <?php endif; ?>
-                        <a href="<?= htmlspecialchars($_timer_href, ENT_QUOTES) ?>" class="nav-mobile-link">Tournament Timer</a>
+                        <a href="<?= htmlspecialchars($_timer_href, ENT_QUOTES | ENT_SUBSTITUTE) ?>" class="nav-mobile-link">Tournament Timer</a>
                         <div class="nav-mobile-divider"></div>
                         <div class="nav-help-group<?= $_active === 'help' || $_active === 'support' ? ' open' : '' ?>">
                             <button type="button" class="nav-help-toggle" data-nav="help">Help <span class="nav-help-caret" aria-hidden="true">&#9656;</span></button>
@@ -191,7 +191,7 @@ $_accent        = get_setting('accent_color', '');
 (function(){
     var l = document.querySelector('link[rel~="icon"]');
     if (!l) { l = document.createElement('link'); l.rel = 'icon'; document.head.appendChild(l); }
-    l.href = '<?= htmlspecialchars($_banner, ENT_QUOTES) ?>?v=<?= $_banner_v ?>';
+    l.href = '<?= htmlspecialchars($_banner, ENT_QUOTES | ENT_SUBSTITUTE) ?>?v=<?= $_banner_v ?>';
 })();
 </script>
 <?php endif; ?>

--- a/www/admin_api_keys.php
+++ b/www/admin_api_keys.php
@@ -121,7 +121,7 @@ function api_keys_admin_fmt(?string $utc_dt, DateTimeZone $local_tz): string {
                     <td><?= htmlspecialchars(api_keys_admin_fmt($k['created_at'], $local_tz)) ?></td>
                     <td><?= htmlspecialchars(api_keys_admin_fmt($k['last_used_at'], $local_tz)) ?></td>
                     <td style="text-align:right">
-                        <form method="post" style="margin:0;display:inline" data-confirm="Delete this API key permanently? Consumers using it will start getting 401 immediately. This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1"">
+                        <form method="post" style="margin:0;display:inline" data-confirm="Delete this API key permanently? Consumers using it will start getting 401 immediately. This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1">
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                             <input type="hidden" name="action" value="revoke">
                             <input type="hidden" name="id" value="<?= (int)$k['id'] ?>">

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -398,7 +398,7 @@ $now_local = (new DateTime('now', $local_tz))->format('Y-m-d H:i:s');
                                 </button>
                             </form>
                             <form method="post" action="/admin_posts.php" style="margin:0"
-                                  data-confirm="Delete this post?" data-confirm-ok="Delete" data-confirm-danger="1"">
+                                  data-confirm="Delete this post?" data-confirm-ok="Delete" data-confirm-danger="1">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="id" value="<?= (int)$p['id'] ?>">

--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -1654,7 +1654,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
                     View Notification Log (<?= $smsLogCount ?>)
                 </a>
                 <form method="post" action="/admin_settings.php"
-                      data-confirm="Clear all log entries? This cannot be undone." data-confirm-danger="1"">
+                      data-confirm="Clear all log entries? This cannot be undone." data-confirm-danger="1">
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                     <input type="hidden" name="action" value="clear_logs">
                     <input type="hidden" name="tab" value="logs">
@@ -1759,7 +1759,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
             <div id="ugBulkBar">
                 <span class="bulk-label"><span id="ugBulkCount">0</span> selected</span>
                 <form id="ugBulkDeleteForm" method="post" action="/admin_settings.php"
-                      data-confirm="Delete selected users? This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1"">
+                      data-confirm="Delete selected users? This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1">
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                     <input type="hidden" name="action" value="bulk_delete">
                     <input type="hidden" name="tab" value="users">
@@ -1871,7 +1871,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
                         <td class="ug-act-cell">
                             <?php if (!$isSelf): ?>
                             <form method="post" action="/admin_settings.php"
-                                  data-confirm="<?= htmlspecialchars('Delete ' . $u['username'] . '? This cannot be undone.', ENT_QUOTES) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
+                                  data-confirm="<?= htmlspecialchars('Delete ' . $u['username'] . '? This cannot be undone.', ENT_QUOTES | ENT_SUBSTITUTE) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                 <input type="hidden" name="action" value="delete">
                                 <input type="hidden" name="tab" value="users">
@@ -2244,7 +2244,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
 
                         <td class="ev-del-cell">
                             <form method="post" action="/admin_settings.php"
-                                  data-confirm="<?= htmlspecialchars('Delete event "' . $ev['title'] . '"? This cannot be undone.', ENT_QUOTES) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
+                                  data-confirm="<?= htmlspecialchars('Delete event "' . $ev['title'] . '"? This cannot be undone.', ENT_QUOTES | ENT_SUBSTITUTE) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                 <input type="hidden" name="action" value="delete_event">
                                 <input type="hidden" name="tab" value="events">
@@ -3204,7 +3204,7 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
                 <h3 style="margin-top:0;color:#dc2626">Restore from Backup</h3>
                 <p style="font-size:.85rem;color:#64748b;margin-bottom:1rem">Upload a previously downloaded <code>.db</code> backup file. This will <strong>replace all current data</strong>.</p>
                 <form method="post" action="/admin_settings.php?tab=backup" enctype="multipart/form-data"
-                      data-confirm="This will REPLACE ALL current data with the backup. The current database will be saved as a safety copy. Continue?" data-confirm-ok="Restore" data-confirm-danger="1"">
+                      data-confirm="This will REPLACE ALL current data with the backup. The current database will be saved as a safety copy. Continue?" data-confirm-ok="Restore" data-confirm-danger="1">
                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                     <input type="hidden" name="action" value="backup_restore">
                     <input type="hidden" name="tab" value="backup">

--- a/www/admin_settings_dl.php
+++ b/www/admin_settings_dl.php
@@ -871,7 +871,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
                 All user activity &mdash; <?= number_format($log_total) ?> total entries.
             </p>
             <form method="post" action="/admin_settings.php"
-                  data-confirm="Clear all log entries? This cannot be undone." data-confirm-danger="1"">
+                  data-confirm="Clear all log entries? This cannot be undone." data-confirm-danger="1">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="clear_logs">
                 <input type="hidden" name="tab" value="logs">
@@ -945,7 +945,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
         <div id="bulkBar">
             <span class="bulk-label"><span id="bulkCount">0</span> selected</span>
             <form id="bulkForm" method="post" action="/admin_settings.php"
-                  data-confirm="Delete selected users? This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1"">
+                  data-confirm="Delete selected users? This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="bulk_delete">
                 <input type="hidden" name="tab" value="users">
@@ -988,7 +988,7 @@ $dash_posts  = (int)$db->query('SELECT COUNT(*) FROM posts')->fetchColumn();
                                    class="btn-icon" title="Edit">&#9881;</a>
                                 <?php if ((int)$u['id'] !== (int)$current['id']): ?>
                                 <form method="post" action="/admin_settings.php"
-                                      data-confirm="<?= htmlspecialchars('Delete ' . $u['username'] . '?', ENT_QUOTES) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
+                                      data-confirm="<?= htmlspecialchars('Delete ' . $u['username'] . '?', ENT_QUOTES | ENT_SUBSTITUTE) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
                                     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                                     <input type="hidden" name="action" value="delete">
                                     <input type="hidden" name="tab" value="users">

--- a/www/calendar.php
+++ b/www/calendar.php
@@ -1786,7 +1786,7 @@ $editorCtx = ($wkStart !== null) ? 'wk=' . urlencode($wkStartStr) : 'm=' . urlen
             <button type="button" class="btn btn-outline" title="Create a new event prefilled from this one (same details and invite list, new date, no RSVPs)" data-act="goCurrentEventCopy">Duplicate</button>
             <?php if ($isAdmin): ?><button type="button" class="btn btn-outline" title="Walk-up QR code" data-act="openWalkinQR" style="font-size:1rem;padding:.38rem .65rem">&#x1F4F1; QR</button><?php endif; ?>
             <form method="post" action="/calendar.php" style="margin:0"
-                  data-confirm="Delete this event?" data-confirm-ok="Delete" data-confirm-danger="1"">
+                  data-confirm="Delete this event?" data-confirm-ok="Delete" data-confirm-danger="1">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="delete">
                 <input type="hidden" name="id" id="vDeleteId">

--- a/www/db.php
+++ b/www/db.php
@@ -1887,7 +1887,7 @@ function render_seo_meta(string $title, string $description, string $path = ''):
     $img    = get_setting('header_banner_path', '');
     if ($img === '') $img = get_setting('banner_path', '');
     $imgAbs = $img !== '' ? $site . $img : '';
-    $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES);
+    $e = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES | ENT_SUBSTITUTE);
     echo "\n    <meta name=\"description\" content=\"" . $e($description) . "\">";
     echo "\n    <link rel=\"canonical\" href=\"" . $e($url) . "\">";
     echo "\n    <meta property=\"og:type\" content=\"website\">";

--- a/www/event.php
+++ b/www/event.php
@@ -257,7 +257,7 @@ if ($token === '' && $page_eid > 0) {
                     <a href="/walkin_display.php?event_id=<?= $page_eid ?>" target="_blank" rel="noopener">&#x1F4F1; Walk-up QR</a>
                     <?php endif; ?>
                     <form method="post" action="/calendar.php" style="margin:0;border-top:1px solid #f1f5f9"
-                          data-confirm="Delete this event?" data-confirm-ok="Delete" data-confirm-danger="1"">
+                          data-confirm="Delete this event?" data-confirm-ok="Delete" data-confirm-danger="1">
                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf) ?>">
                         <input type="hidden" name="action" value="delete">
                         <input type="hidden" name="id" value="<?= $page_eid ?>">

--- a/www/event_polls.php
+++ b/www/event_polls.php
@@ -211,7 +211,7 @@ $backUrl   = '/calendar.php?m=' . urlencode(substr($event['start_date'], 0, 7)) 
             <div style="display:flex;gap:.5rem;margin-top:.5rem">
                 <button type="button" class="pl-btn" data-act="addQuestion">+ Add question</button>
                 <div style="flex:1"></div>
-                <button type="submit" class="pl-btn primary" data-confirm="Send this poll to &lt;?= count($audienceNow) ?> Yes/Maybe guest(s) now?">Create &amp; Send</button>
+                <button type="submit" class="pl-btn primary" data-confirm="Send this poll to <?= count($audienceNow) ?> Yes/Maybe guest(s) now?">Create &amp; Send</button>
             </div>
             <p class="pl-meta" style="margin:.6rem 0 0">Questions can't be edited once anyone has voted &mdash; close the poll and make a new one instead.</p>
         </form>
@@ -266,7 +266,7 @@ $backUrl   = '/calendar.php?m=' . urlencode(substr($event['start_date'], 0, 7)) 
                 <input type="hidden" name="poll_id" value="<?= (int)$p['id'] ?>">
                 <button type="submit" class="pl-btn" title="Sends only to Yes/Maybe guests who haven't received this poll yet">Send to new respondents</button>
             </form>
-            <form method="post" action="/event_polls.php" style="margin:0" data-confirm="Close this poll? Nobody will be able to vote anymore."">
+            <form method="post" action="/event_polls.php" style="margin:0" data-confirm="Close this poll? Nobody will be able to vote anymore.">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="close">
                 <input type="hidden" name="event_id" value="<?= $eventId ?>">
@@ -310,7 +310,7 @@ function addQuestion() {
         '<button type="button" class="pl-btn danger" data-remove-closest=".pl-q\" title="Remove question">&times;</button>' +
         '</div>' +
         '<div class="pl-opts"></div>' +
-        '<button type="button" class="pl-btn" style="margin-top:.4rem" data-act="addOption" data-a1="@self" data-a2=" + i + ">+ Option</button>';
+        '<button type="button" class="pl-btn" style="margin-top:.4rem" data-act="addOption" data-a1="@self" data-a2="' + i + '">+ Option</button>';
     wrap.appendChild(div);
     addOption(div.querySelector('button:last-child'), i);
     addOption(div.querySelector('button:last-child'), i);

--- a/www/index.php
+++ b/www/index.php
@@ -821,16 +821,10 @@ document.addEventListener('submit', function (e) {
         if (prepareBulkDelete(parseInt(f.dataset.post, 10), f) === false) e.preventDefault();
         return;
     }
-    // Generic confirm-before-submit, replacing onsubmit="return pkConfirmForm(...)".
-    // pkConfirmForm() resolves the dialog and then calls formEl.submit(), which
-    // does NOT fire the submit event again, so this cannot recurse.
-    if (f.dataset && f.dataset.confirm) {
-        e.preventDefault();
-        pkConfirmForm(f, f.dataset.confirm, {
-            okLabel: f.dataset.confirmOk || 'OK',
-            danger:  f.dataset.confirmDanger === '1'
-        });
-    }
+    // data-confirm is handled by the shared pk-dispatch.js, which every page
+    // gets from _footer.php. Handling it here as well fired two stacked confirm
+    // dialogs on delete-post and delete-comment — the same double-dispatch class
+    // that v0.2078 fixed for checkin.php.
 });
 
 function toggleComments(postId) {

--- a/www/league.php
+++ b/www/league.php
@@ -841,7 +841,7 @@ function ordinal($n) {
                                 <?php elseif ($isOwner): ?>
                                     <button class="mg-iconbtn" title="Transfer ownership" data-act="act" data-a1="transfer_ownership" data-a2="<?= (int)$targetUid ?>" data-a3="Transfer ownership to this member? You will be demoted to member.">&#9812;</button>
                                 <?php endif; ?>
-                                <button class="mg-iconbtn mg-iconbtn-danger" title="Remove" data-act="removeMember" data-a1="<?= (int)$memId ?>" data-a2="<?= htmlspecialchars($isPending ? 'Remove this pending contact?' : 'Remove this member from the league?', ENT_QUOTES) ?>">&times;</button>
+                                <button class="mg-iconbtn mg-iconbtn-danger" title="Remove" data-act="removeMember" data-a1="<?= (int)$memId ?>" data-a2="<?= htmlspecialchars($isPending ? 'Remove this pending contact?' : 'Remove this member from the league?', ENT_QUOTES | ENT_SUBSTITUTE) ?>">&times;</button>
                             </div>
                         <?php endif; ?>
                     </td>
@@ -1026,7 +1026,7 @@ function ordinal($n) {
                         <strong style="min-width:0"><?= htmlspecialchars($s['name']) ?></strong>
                         <span style="color:#94a3b8"><?= htmlspecialchars($s['start_date']) ?> &rarr; <?= htmlspecialchars($s['end_date']) ?></span>
                         <form method="post" action="/league.php?id=<?= $league_id ?>" style="margin:0 0 0 auto"
-                              data-confirm="Delete this season? Standings history is unaffected — only the saved date window is removed." data-confirm-ok="Delete" data-confirm-danger="1"">
+                              data-confirm="Delete this season? Standings history is unaffected — only the saved date window is removed." data-confirm-ok="Delete" data-confirm-danger="1">
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                             <input type="hidden" name="action" value="season_delete">
                             <input type="hidden" name="season_id" value="<?= (int)$s['id'] ?>">
@@ -1215,7 +1215,7 @@ function ordinal($n) {
                         <?php endif; ?>
                         <?php if ($canPost): ?>
                         <form method="post" action="/league_posts_dl.php" style="margin:0"
-                              data-confirm="Unset this post as the league rules? It will reappear in the main feed."">
+                              data-confirm="Unset this post as the league rules? It will reappear in the main feed.">
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                             <input type="hidden" name="action" value="clear_rules">
                             <input type="hidden" name="post_id" value="<?= (int)$rulesPost['id'] ?>">
@@ -1381,7 +1381,7 @@ function ordinal($n) {
                 <?php $__pbtn = 'font-size:.72rem;padding:.25rem .7rem;min-width:72px;text-align:center;line-height:1.2;box-sizing:border-box;display:inline-flex;align-items:center;justify-content:center'; ?>
                 <div style="margin-left:auto;display:flex;gap:.4rem;align-items:center;flex-wrap:wrap">
                     <a href="?id=<?= $league_id ?>&tab=posts&edit=<?= (int)$lp['id'] ?>" class="lg-btn lg-btn-ghost" style="<?= $__pbtn ?>">Edit</a>
-                    <form method="post" action="/league_posts_dl.php" style="margin:0" data-confirm="Delete this post?" data-confirm-ok="Delete" data-confirm-danger="1"">
+                    <form method="post" action="/league_posts_dl.php" style="margin:0" data-confirm="Delete this post?" data-confirm-ok="Delete" data-confirm-danger="1">
                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                         <input type="hidden" name="action" value="delete">
                         <input type="hidden" name="post_id" value="<?= (int)$lp['id'] ?>">
@@ -1390,7 +1390,7 @@ function ordinal($n) {
                     </form>
                     <?php if ($canPost): ?>
                     <form method="post" action="/league_posts_dl.php" style="margin:0"
-                          data-confirm="<?= htmlspecialchars($rulesPost ? 'This will replace the current league rules post. Continue?' : 'Mark this post as the league rules? It will be moved out of the main feed and accessible via the League Rules button.', ENT_QUOTES) ?>">
+                          data-confirm="<?= htmlspecialchars($rulesPost ? 'This will replace the current league rules post. Continue?' : 'Mark this post as the league rules? It will be moved out of the main feed and accessible via the League Rules button.', ENT_QUOTES | ENT_SUBSTITUTE) ?>">
                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                         <input type="hidden" name="action" value="set_rules">
                         <input type="hidden" name="post_id" value="<?= (int)$lp['id'] ?>">
@@ -1569,7 +1569,7 @@ function ordinal($n) {
                         <td style="padding:.55rem .6rem;border-bottom:1px solid #f1f5f9"><?= htmlspecialchars($ak_fmt($k['created_at'])) ?></td>
                         <td style="padding:.55rem .6rem;border-bottom:1px solid #f1f5f9"><?= htmlspecialchars($ak_fmt($k['last_used_at'])) ?></td>
                         <td style="padding:.55rem .6rem;border-bottom:1px solid #f1f5f9;text-align:right">
-                            <form method="post" action="/league_api_keys_dl.php" style="margin:0;display:inline" data-confirm="Delete this API key permanently? Consumers using it will start getting 401 immediately. This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1"">
+                            <form method="post" action="/league_api_keys_dl.php" style="margin:0;display:inline" data-confirm="Delete this API key permanently? Consumers using it will start getting 401 immediately. This cannot be undone." data-confirm-ok="Delete" data-confirm-danger="1">
                                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(csrf_token()) ?>">
                                 <input type="hidden" name="action" value="revoke">
                                 <input type="hidden" name="key_id" value="<?= (int)$k['id'] ?>">

--- a/www/leagues.php
+++ b/www/leagues.php
@@ -139,7 +139,7 @@ $csrf = csrf_token();
                 <?php elseif ($l['approval_mode'] === 'auto'): ?>
                     <button class="lg-btn" data-act="joinLeague" data-a1="<?= (int)$l['id'] ?>">Join</button>
                 <?php else: ?>
-                    <button class="lg-btn" data-act="openRequestModal" data-a1="<?= (int)$l['id'] ?>" data-a2="<?= htmlspecialchars(json_encode($l['name']), ENT_QUOTES) ?>">Request to Join</button>
+                    <button class="lg-btn" data-act="openRequestModal" data-a1="<?= (int)$l['id'] ?>" data-a2="<?= htmlspecialchars($l['name'], ENT_QUOTES | ENT_SUBSTITUTE) ?>">Request to Join</button>
                 <?php endif; ?>
             </div>
         <?php endforeach; ?>

--- a/www/messages.php
+++ b/www/messages.php
@@ -193,7 +193,7 @@ setInterval(pollList, 5000);
 function startDmWithSelected() {
     var v = document.getElementById('dmNewUser').value;
     if (!v) { pkAlert('Pick a person first.'); return; }
-    location.href = '/message_thread.php?with=' + encodeURIComponent(v);
+    location.href = '/message_thread.php?user=' + encodeURIComponent(v);
 }
 </script>
 </body>

--- a/www/pk-dispatch.js
+++ b/www/pk-dispatch.js
@@ -110,9 +110,17 @@
     document.addEventListener('click', function (e) {
         if (!(e.target instanceof Element)) return;
 
-        // data-href: a plain navigation that used to be location.href='...'
-        var nav = e.target.closest('[data-href]');
-        if (nav) { e.preventDefault(); window.location.href = nav.getAttribute('data-href'); return; }
+        // data-href: a plain navigation that used to be location.href='...'.
+        // Honours data-stop as a boundary exactly like data-act above: a row can
+        // be a link while a control inside it does something else. Without this,
+        // the Message button inside a contacts row navigated to the row's href.
+        var nav = e.target.closest('[data-href], [data-stop]');
+        if (nav && !nav.hasAttribute('data-stop')) {
+            e.preventDefault();
+            window.location.href = nav.getAttribute('data-href');
+            return;
+        }
+        if (nav) return;
 
         // data-toggle-class="targetId:className" (className defaults to "open")
         var tog = e.target.closest('[data-toggle-class]');

--- a/www/settings.php
+++ b/www/settings.php
@@ -291,7 +291,7 @@ $site_name = get_setting('site_name', 'Game Night');
                         <button type="button" class="btn btn-outline" style="font-size:.82rem" data-click-file="stAvatarFile">Upload photo</button>
                         <input type="file" id="stAvatarFile" accept="image/*" style="display:none">
                         <?php if (!empty($current['avatar_path'])): ?>
-                        <form method="post" action="/settings.php" style="margin:0" data-confirm="Remove your profile photo?" data-confirm-ok="Remove" data-confirm-danger="1"">
+                        <form method="post" action="/settings.php" style="margin:0" data-confirm="Remove your profile photo?" data-confirm-ok="Remove" data-confirm-danger="1">
                             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                             <input type="hidden" name="action" value="remove_avatar">
                             <button type="submit" class="btn btn-outline" style="font-size:.82rem;color:#dc2626;border-color:#fecaca">Remove</button>

--- a/www/sitemap.php
+++ b/www/sitemap.php
@@ -26,7 +26,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
 echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . "\n";
 foreach ($pages as [$path, $priority, $freq]) {
     $loc = $site . '/' . ltrim($path, '/');
-    echo '  <url><loc>' . htmlspecialchars($loc, ENT_QUOTES) . '</loc>'
+    echo '  <url><loc>' . htmlspecialchars($loc, ENT_QUOTES | ENT_SUBSTITUTE) . '</loc>'
        . '<changefreq>' . $freq . '</changefreq>'
        . '<priority>' . $priority . '</priority></url>' . "\n";
 }
@@ -39,7 +39,7 @@ try {
          ORDER BY slug"
     )->fetchAll();
     foreach ($pub as $r) {
-        echo '  <url><loc>' . htmlspecialchars($site . '/league/' . $r['slug'], ENT_QUOTES) . '</loc>'
+        echo '  <url><loc>' . htmlspecialchars($site . '/league/' . $r['slug'], ENT_QUOTES | ENT_SUBSTITUTE) . '</loc>'
            . '<changefreq>weekly</changefreq><priority>0.6</priority></url>' . "\n";
     }
 } catch (Exception $e) {}

--- a/www/sms_log.php
+++ b/www/sms_log.php
@@ -113,7 +113,7 @@ unset($_SESSION['flash']);
         <h2>Notification Log (<?= $smsLogCount ?>)<?= $f_event_title !== '' ? ' — ' . htmlspecialchars($f_event_title) : '' ?></h2>
         <div class="sms-log-actions">
             <?php if ($isAdmin && $smsLogCount > 0): ?>
-            <form method="post" style="margin:0" data-confirm="Clear all SMS logs?" data-confirm-danger="1"">
+            <form method="post" style="margin:0" data-confirm="Clear all SMS logs?" data-confirm-danger="1">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="sms_clear_log">
                 <button type="submit" class="btn btn-outline" style="font-size:.8rem;padding:.35rem .75rem;color:#dc2626;border-color:#fca5a5">Clear Log</button>
@@ -206,7 +206,7 @@ unset($_SESSION['flash']);
                         <td class="col-raw">
                             <?php if (!empty($log['raw_response'])): ?>
                                 <button type="button"
-                                        data-raw="<?= htmlspecialchars($log['raw_response'], ENT_QUOTES) ?>"
+                                        data-raw="<?= htmlspecialchars($log['raw_response'], ENT_QUOTES | ENT_SUBSTITUTE) ?>"
                                         data-act="copySmsRaw" data-a1="@self"
                                         class="btn btn-outline btn-sm">Copy</button>
                             <?php else: ?>

--- a/www/timer.php
+++ b/www/timer.php
@@ -4506,7 +4506,6 @@ function renderPresetCard(preset) {
     }
     function esc(s){ return String(s==null?'':s).replace(/[&<>"]/g,function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c];}); }
     var ev = el.event_name || {}, bl = el.blinds || {}, ck = el.clock || {};
-    var keyJson = JSON.stringify(preset.key);
 
     var card = document.createElement('div');
     card.className = 'preset-card';
@@ -4522,8 +4521,8 @@ function renderPresetCard(preset) {
         '<div class="preset-foot">' +
             '<span class="preset-name" title="' + esc(preset.name) + '">' + esc(preset.name) + '</span>' +
             '<span style="display:flex;gap:.3rem;flex:0 0 auto">' +
-                '<button data-act="loadPresetTheme" data-a1="' + esc(keyJson) + '">Load</button>' +
-                (IS_ADMIN ? '<button data-act="deletePresetTheme" data-a1="' + esc(keyJson) + '" title="Delete preset file">&times;</button>' : '') +
+                '<button data-act="loadPresetTheme" data-a1="' + esc(preset.key) + '">Load</button>' +
+                (IS_ADMIN ? '<button data-act="deletePresetTheme" data-a1="' + esc(preset.key) + '" title="Delete preset file">&times;</button>' : '') +
             '</span>' +
         '</div>';
     return card;

--- a/www/user_edit.php
+++ b/www/user_edit.php
@@ -295,7 +295,7 @@ $site_name = get_setting('site_name', 'Game Night');
                 If this user lost their device <em>and</em> their recovery codes, reset it so they can sign in with just their password and re-enroll.
             </p>
             <form method="post" action="/user_edit.php?id=<?= $id ?>"
-                  data-confirm="<?= htmlspecialchars('Reset (disable) two-factor for ' . $target['username'] . '? They will sign in with just their password until they set it up again.', ENT_QUOTES) ?>" data-confirm-danger="1">
+                  data-confirm="<?= htmlspecialchars('Reset (disable) two-factor for ' . $target['username'] . '? They will sign in with just their password until they set it up again.', ENT_QUOTES | ENT_SUBSTITUTE) ?>" data-confirm-danger="1">
                 <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
                 <input type="hidden" name="action" value="reset_mfa">
                 <button type="submit" class="btn" style="width:100%;background:#dc2626;color:#fff;border:none;font-weight:600">Reset Two-Factor</button>
@@ -336,7 +336,7 @@ $site_name = get_setting('site_name', 'Game Night');
             Permanently delete this account and all associated activity logs. This cannot be undone.
         </p>
         <form method="post" action="/user_edit.php?id=<?= $id ?>"
-              data-confirm="<?= htmlspecialchars('Permanently delete ' . $target['username'] . '? This cannot be undone.', ENT_QUOTES) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
+              data-confirm="<?= htmlspecialchars('Permanently delete ' . $target['username'] . '? This cannot be undone.', ENT_QUOTES | ENT_SUBSTITUTE) ?>" data-confirm-ok="Delete" data-confirm-danger="1">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">
             <input type="hidden" name="action" value="delete">
             <button type="submit" class="btn" style="background:#dc2626;color:#fff">

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2081');
+define('APP_VERSION', '0.2082');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Converting 401 inline `on*` attributes to declarative `data-act` markup across v0.2074-0.2079 broke a handful of controls in ways a lint pass could not see. The second security review surfaced them; none are security issues, but several were live.

### Fixed

- **`index.php` raised two stacked confirm dialogs** on delete-post and delete-comment. It kept its own document-level `submit` listener for `data-confirm` while also receiving the shared `pk-dispatch.js` — the same double-dispatch class that v0.2078 fixed for `checkin.php`. The duplicate listener is gone and the shared dispatcher owns the behaviour.
- **The Start button on `messages.php`** navigated to `message_thread.php?with=` while that page reads `?user=`.
- **`data-href` ignored `data-stop`**, so the Message button inside a contacts row navigated to the row's edit page. It now honours the boundary exactly as `data-act` does.
- **`event_polls.php`** had a PHP tag HTML-escaped into a confirm message, and a JS concatenation emitted literally into the + Option button.
- **`leagues.php`** passed a `json_encode()` result into an attribute, so the join modal showed quoted text.
- **`timer.php`** handed `loadPresetTheme`/`deletePresetTheme` a JSON-quoted preset key.
- **Sixteen attributes across ten files** carried a stray duplicated closing quote such as `data-confirm-danger="1""`.
- **A confirmation could silently disappear on invalid UTF-8.** The converted `data-confirm` attributes build their text with `htmlspecialchars(..., ENT_QUOTES)`, which returns an empty string when the input contains an invalid UTF-8 byte — so an event title or username carrying one produced an empty `data-confirm` and no dialog at all. All such call sites now pass `ENT_QUOTES | ENT_SUBSTITUTE`. Client-side guard only; the POST remains CSRF-protected and server-authorised either way.

### Infrastructure

- **The double-dispatch sweep now covers the generic behaviours.** It only counted named `data-act*` functions, which is why it passed a release containing the `index.php` double-confirm — `data-confirm` names no function, so there was nothing to count. It now stubs `pkConfirmForm()` and asserts exactly one call per `data-confirm` form and button, and flags any `data-*` attribute still holding an unresolved `<?= ?>` or a stray JS concatenation.
- **The sweep had been running as a non-admin the whole time**, so every admin page returned 403 and reported zero controls — including five of the files fixed here. It now fails loudly when the admin pages are unreachable instead of reporting a clean pass over nothing. Real coverage went from 262 to 558 controls.

Verified on dev: each fix driven through its actual control (8/8), the double-dialog proved in both directions by re-adding the old listener at runtime (2 calls) versus the shipped code (1), plus `csp_nonce.js` 29/29 and `pages_dispatch.js` clean across 171 controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)