### PR TITLE
Manage Posts: Edit opened nothing, and add a View action (v0.2084)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2084] - 2026-08-10
+
+### Fixed
+- **Edit did nothing on Manage Posts, and there was no way to view a post.** Clicking Edit navigated to `/admin_posts.php?edit=N` and left the page looking inert. The cause was a load-order race introduced when Jodit moved to a local `defer`red script: `editor` is created inside a `DOMContentLoaded` listener, but the `?edit=N` deep link called `openModal()` inline at parse time, so `editor` was still `null`. `openModal()` threw on `editor.value` and aborted three lines before `postModal.classList.add('open')` — no modal, and the only symptom was one console error nobody was looking at. The auto-open call now runs in its own `DOMContentLoaded` listener; listeners fire in registration order and the editor init registers first, so the editor is guaranteed to exist. Checked the other three pages that load Jodit deferred: `calendar.php` and `league.php` have no parse-time call, and `event.php` builds its editor lazily in `_emEnsureEditor()`, so none share the defect.
+- **Added a View action to Manage Posts.** The actions column offered only Edit, Pin and Delete, so there was no route from the admin table to the post itself. Each row now links to the post's feed anchor (`/#post-<id>`). Hidden posts get a greyed, non-clickable placeholder with an explanatory tooltip instead of a dead link, because `posts_feed_sql_for_user()` filters `p.hidden = 0` unconditionally — a hidden post is absent from the feed for everyone, admins included. Both states verified against fixtures.
+
 ## [v0.2083] - 2026-08-10
 
 ### Fixed

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -379,6 +379,13 @@ $now_local = (new DateTime('now', $local_tz))->format('Y-m-d H:i:s');
                     <td></td>
                     <td>
                         <div class="action-btns">
+                            <?php if (!$p['hidden']): ?>
+                                <a href="/#post-<?= (int)$p['id'] ?>"
+                                   class="btn-sm-text">View</a>
+                            <?php else: ?>
+                                <span class="btn-sm-text muted" style="cursor:default"
+                                      title="Hidden posts are excluded from the feed, so there is nothing to view">View</span>
+                            <?php endif; ?>
                             <a href="/admin_posts.php?edit=<?= (int)$p['id'] ?>"
                                class="btn-sm-text">Edit</a>
                             <form method="post" action="/admin_posts.php" style="margin:0">
@@ -664,6 +671,12 @@ async function bulkDelete() {
 }
 
 <?php if ($edit_post): ?>
+// jodit.min.js is deferred, so `editor` is not created until DOMContentLoaded
+// (see the init block above). Calling openModal() at parse time therefore threw
+// on `editor.value` and aborted before the modal was shown, so ?edit=N left the
+// page looking inert. Listeners run in registration order and the init block
+// registered first, so by the time this fires the editor exists.
+document.addEventListener('DOMContentLoaded', function () {
 openModal(
     <?= (int)$edit_post['id'] ?>,
     <?= json_encode($edit_post['title']) ?>,
@@ -672,6 +685,7 @@ openModal(
     <?= (int)$edit_post['pinned'] ?>,
     <?= (int)($edit_post['league_id'] ?? 0) ?>
 );
+});
 <?php endif; ?>
 </script>
 

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2083');
+define('APP_VERSION', '0.2084');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Fixed

**Edit did nothing.** Clicking Edit on Manage Posts navigated to `/admin_posts.php?edit=N` and left the page looking inert.

A load-order race, introduced when Jodit moved to a local `defer`red script. `editor` is created inside a `DOMContentLoaded` listener:

```js
let editor = null;
document.addEventListener('DOMContentLoaded', function () {
    editor = Jodit.make('#jodit-editor', { … });
```

but the `?edit=N` deep link called `openModal()` inline at parse time, before that fires. `openModal()` threw on `editor.value = content` and aborted three lines before `postModal.classList.add('open')`. No modal, and the only symptom was a single console error:

```
TypeError: Cannot set properties of null (setting 'value')
    at openModal (admin_posts.php?edit=24:694:18)
```

The auto-open call now runs in its own `DOMContentLoaded` listener. Listeners fire in registration order and the editor init registers first, so the editor is guaranteed to exist by then.

Swept the other three pages that load Jodit deferred: `calendar.php` and `league.php` have no parse-time call, and `event.php` builds its editor lazily in `_emEnsureEditor()`. None share the defect.

**Added a View action.** The actions column offered only Edit, Pin and Delete, so there was no route from the admin table to the post itself. Each row now links to the post's feed anchor (`/#post-<id>`).

Hidden posts get a greyed, non-clickable placeholder with an explanatory tooltip rather than a dead link: `posts_feed_sql_for_user()` applies `p.hidden = 0` unconditionally, so a hidden post is absent from the feed for everyone, admins included.

### Verification

Reproduced the failure first (modal `display: none` plus the thrown TypeError), then confirmed the fix by clicking Edit as a user does: modal opens, title reads "Edit Post", the form is populated and the editor carries the post body. The View link resolves to an anchor that exists in the feed; the hidden placeholder was verified by temporarily hiding a post and restoring it.

Suites: double-dispatch sweep 557 controls / 29 passed / 0 failed, `csp_nonce.js` 29/29, sweeps 1 and 3 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)