### PR TITLE
Timer: arrow-key level skip, shared control guard (v0.2086)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2086] - 2026-08-12
+
+### Added
+- **Keyboard shortcuts to run the tournament timer.** The timer already toggled start/stop on the spacebar; it now also skips levels with the arrow keys: Right advances to the next level, Left steps back to the previous one. All three are gated by a new shared `timerControlArmed()` (which the clock double-tap now also uses): the shortcut fires only when the user can control this timer and is not in the layout editor, and never while typing in an input, textarea, select or contenteditable. The spacebar handler previously fired regardless of control state or edit mode; it now respects the same guard. The server re-checks manage rights on every command either way, so this only affects which keypresses reach the wire.
+
 ## [v0.2085] - 2026-08-11
 
 ### Fixed

--- a/www/timer.js
+++ b/www/timer.js
@@ -683,15 +683,18 @@ function togglePlay() { sendCommand('toggle_play'); }
 // Double-tap / double-click the clock to start or pause. The tray button stays
 // the primary control; this is for the host standing at the table with a tablet
 // propped up, where hitting a small button is the awkward part.
+// Control is armed when the user can control this timer and isn't in the layout
+// editor (where the clock is a draggable object). Shared by the clock
+// double-tap and the keyboard shortcuts; the server re-checks on every command.
+function timerControlArmed() {
+    return CAN_CONTROL && !document.body.classList.contains('layout-edit');
+}
+
 (function () {
     var clock = document.getElementById('timerClock');
     if (!clock) return;
 
-    function armed() {
-        // A viewer must never be able to control the game, and in the layout
-        // editor the clock is a draggable object rather than a button.
-        return CAN_CONTROL && !document.body.classList.contains('layout-edit');
-    }
+    function armed() { return timerControlArmed(); }
     function toggleFromClock(e) {
         if (!armed()) return;
         if (e && e.preventDefault) e.preventDefault();
@@ -4047,12 +4050,16 @@ if (tray) {
     }, { passive: true });
 }
 
-// Spacebar hotkey for start/stop (only when not typing in an input)
+// Keyboard control: Space start/stop, Left/Right previous/next level. Gated on
+// the same conditions as the clock double-tap (armed()): the user can control
+// this timer and isn't in layout-edit mode, and isn't typing in a field. The
+// server re-checks manage rights on every command regardless.
 document.addEventListener('keydown', function(e) {
-    if (e.code === 'Space' && !e.target.closest('input, textarea, select, [contenteditable]')) {
-        e.preventDefault();
-        togglePlay();
-    }
+    if (e.target.closest('input, textarea, select, [contenteditable]')) return;
+    if (!timerControlArmed()) return;
+    if (e.code === 'Space') { e.preventDefault(); togglePlay(); }
+    else if (e.code === 'ArrowRight') { e.preventDefault(); skipLevel(1); }
+    else if (e.code === 'ArrowLeft')  { e.preventDefault(); skipLevel(-1); }
 });
 
 // Open TV display mode in a new tab (for casting/TV browser)

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2085');
+define('APP_VERSION', '0.2086');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Added

**Keyboard shortcuts to run the tournament timer.** The timer already toggled start/stop on the spacebar; it now also skips levels with the arrow keys — **Right** advances to the next level, **Left** steps back to the previous one.

All three are gated by a new shared `timerControlArmed()`: a shortcut fires only when the user can control this timer (`CAN_CONTROL`) and is **not** in the layout editor, and never while typing in an input, textarea, select or contenteditable. The clock double-tap now uses the same helper (it previously had its own copy trapped in an IIFE). The spacebar handler used to fire regardless of control state or edit mode — it now honours the same guard. The server re-checks manage rights on every command either way, so this only governs which keypresses reach the wire.

### Verification

`timer_hotkeys.js` 6/6 — Right sends `skip_next`, Left sends `skip_prev`, Space sends `toggle_play`, all suppressed while typing, no JS errors. Plus an explicit guard test: a viewer is blocked, layout-edit mode is blocked, a controller fires (verified by toggling `CAN_CONTROL` and the `layout-edit` class at runtime). All timer regressions green: `timer_args` 954 dispatches, `blinds_fit` 48, `clock_doubletap` 10, `timer_gestures` 10, double-dispatch sweep 561, `csp_nonce` 29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)