### PR TITLE
Namespace uploads by feature, with provenance + stronger image check (v0.2087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2087] - 2026-08-12
+
+### Changed
+- **Uploads are namespaced by feature instead of one flat folder.** Every image used to land in a single `/uploads/` directory as an anonymous `bin2hex().ext` file, mixing avatars, post images, and ticket screenshots with no way to tell them apart, attribute them, or clean them up. `upload.php` now takes a whitelisted `feature` parameter (`avatars`, `posts`, `tickets`) — never free-form, so it cannot traverse — that routes uploads into `/uploads/<feature>/` and names them owner-keyed as `u<id>_<random>.ext`, so a file's purpose and owner are visible from its path. A request with no (or an unknown) feature keeps the historical flat `/uploads/<hash>` behaviour, so anything that does not opt in is unchanged. The avatar (`settings.php`), post-image (`admin_posts.php`, `league.php`), and ticket-screenshot (`support.php`, `support_ticket.php`) callers were repointed to their folders; the site banner keeps its own separate fixed-name handler.
+
+### Security
+- **Uploads now require a real, decodable image.** `upload.php` adds a `getimagesize()` check on top of the existing byte-level MIME sniff, so a file that merely reports an image MIME but does not decode as one is rejected.
+- **Fixed three path validators that were pinned to the old flat upload shape.** `set_avatar` (settings.php), `clean_screenshot` (support_dl.php), and `avatar_html` rendering (db.php) each matched only `^/uploads/<32hex>.ext$` and would have silently rejected the new namespaced paths; they now accept both the legacy flat and the namespaced `/uploads/<feature>/u<id>_…` forms. `sanitize_html` already allowed relative image paths, so post images needed no change. Verified end to end on dev: avatar, post image, and ticket screenshot all upload, store, and render from their namespaced folders, with legacy flat paths still served.
+
 ## [v0.2086] - 2026-08-12
 
 ### Added

--- a/www/admin_posts.php
+++ b/www/admin_posts.php
@@ -526,6 +526,7 @@ editor = Jodit.make('#jodit-editor', {
         method: 'POST',
         prepareData: function (formData) {
             formData.append('csrf_token', csrfToken);
+            formData.append('feature', 'posts');
         },
         isSuccess: function (resp) { return !!resp.url; },
         getMsg:    function (resp) { return resp.error || 'Upload failed'; },
@@ -548,6 +549,7 @@ editor = Jodit.make('#jodit-editor', {
 async function uploadImageToEditor(file, ed) {
     const form = new FormData();
     form.append('csrf_token', csrfToken);
+    form.append('feature', 'posts');
     form.append('files[0]', file);
     try {
         const res  = await fetch('/upload.php', { method: 'POST', body: form });

--- a/www/db.php
+++ b/www/db.php
@@ -2443,7 +2443,7 @@ function avatar_hue(string $name): int {
 function avatar_html(string $username, ?string $avatarPath = null, int $size = 32, string $extraClass = ''): string {
     $cls = 'gn-avatar' . ($extraClass !== '' ? ' ' . $extraClass : '');
     $dim = 'width:' . $size . 'px;height:' . $size . 'px';
-    if ($avatarPath && preg_match('#^/uploads/[a-zA-Z0-9._-]+$#', $avatarPath)) {
+    if ($avatarPath && preg_match('#^/uploads/[a-zA-Z0-9._/-]+$#', $avatarPath)) {
         return '<img class="' . htmlspecialchars($cls) . '" src="' . htmlspecialchars($avatarPath)
              . '" alt="' . htmlspecialchars($username) . '" style="' . $dim . '">';
     }

--- a/www/league.php
+++ b/www/league.php
@@ -1328,7 +1328,7 @@ function ordinal($n) {
                         url: '/upload.php',
                         headers: {},
                         format: 'json',
-                        prepareData: function(fd) { fd.append('csrf_token', '<?= htmlspecialchars(csrf_token()) ?>'); return fd; },
+                        prepareData: function(fd) { fd.append('csrf_token', '<?= htmlspecialchars(csrf_token()) ?>'); fd.append('feature', 'posts'); return fd; },
                         isSuccess: function(r){ return r && r.ok; },
                         process: function(r){ return { files: [r.url], baseurl: '' }; },
                         defaultHandlerSuccess: function(data){ var img = this.j.createInside.element('img'); img.setAttribute('src', data.files[0]); this.j.s.insertImage(img); }

--- a/www/settings.php
+++ b/www/settings.php
@@ -22,7 +22,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($action === 'set_avatar') {
             // Path comes from upload.php (validated to its exact output shape).
             $path = trim($_POST['avatar_path'] ?? '');
-            if (preg_match('#^/uploads/[a-f0-9]{32}\.(jpg|png|gif|webp)\z#', $path)) {
+            // Legacy flat path OR the namespaced avatars/u<id>_… that upload.php now returns.
+            if (preg_match('#^/uploads/(avatars/u\d+_)?[a-f0-9]{32}\.(jpg|png|gif|webp)\z#', $path)) {
                 $db->prepare('UPDATE users SET avatar_path = ? WHERE id = ?')->execute([$path, $current['id']]);
                 db_log_activity($current['id'], 'set profile photo');
                 $flash = ['type' => 'success', 'msg' => 'Profile photo updated.'];
@@ -313,6 +314,7 @@ $site_name = get_setting('site_name', 'Game Night');
                 var fd = new FormData();
                 fd.append('csrf_token', <?= json_encode($token) ?>);
                 fd.append('image', f);
+                fd.append('feature', 'avatars');
                 var self = this;
                 fetch('/upload.php', { method: 'POST', body: fd, credentials: 'same-origin' })
                     .then(function (r) { return r.json(); })

--- a/www/support.php
+++ b/www/support.php
@@ -106,6 +106,7 @@ document.getElementById('spShot').addEventListener('change', function () {
     var fd = new FormData();
     fd.append('csrf_token', CSRF);
     fd.append('image', f);
+    fd.append('feature', 'tickets');
     var input = this;
     fetch('/upload.php', { method: 'POST', body: fd, credentials: 'same-origin' })
         .then(function (r) { return r.json(); })

--- a/www/support_dl.php
+++ b/www/support_dl.php
@@ -32,7 +32,8 @@ function clean_screenshot(?string $path): ?string {
     $path = trim((string)$path);
     if ($path === '') return null;
     // \z (not $) so a trailing newline can't sneak into the stored path.
-    if (!preg_match('#^/uploads/[a-f0-9]{32}\.(jpg|png|gif|webp)\z#', $path)) return null;
+    // Legacy flat path OR the namespaced tickets/u<id>_… that upload.php now returns.
+    if (!preg_match('#^/uploads/(tickets/u\d+_)?[a-f0-9]{32}\.(jpg|png|gif|webp)\z#', $path)) return null;
     return $path;
 }
 

--- a/www/support_ticket.php
+++ b/www/support_ticket.php
@@ -119,6 +119,7 @@ document.getElementById('stShot').addEventListener('change', function () {
     var fd = new FormData();
     fd.append('csrf_token', CSRF);
     fd.append('image', f);
+    fd.append('feature', 'tickets');
     var input = this;
     fetch('/upload.php', { method: 'POST', body: fd, credentials: 'same-origin' })
         .then(function (r) { return r.json(); })

--- a/www/upload.php
+++ b/www/upload.php
@@ -61,6 +61,15 @@ if (!isset($exts[$mime])) {
     exit;
 }
 
+// Must actually decode as an image, not merely start with the right magic bytes
+// — rejects a crafted file that sniffs as an image type but is not a real one.
+if (@getimagesize($file['tmp_name']) === false) {
+    http_response_code(400);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'That file is not a readable image.']);
+    exit;
+}
+
 // 8 MB limit
 if ($file['size'] > 8 * 1024 * 1024) {
     http_response_code(400);
@@ -84,12 +93,26 @@ if ($current['role'] !== 'admin') {
     }
 }
 
-$uploadDir = __DIR__ . '/uploads/';
-if (!is_dir($uploadDir)) {
-    mkdir($uploadDir, 0755, true);
+// Per-feature subfolder. Whitelisted (never free-form, so the param can't
+// traverse), so each feature's images live apart instead of one flat dump:
+// easier to reason about, sweep, and back up. An absent/unknown feature keeps
+// the historical flat /uploads/ for backward compatibility.
+$features = ['avatars', 'posts', 'tickets'];
+$feature = (isset($_POST['feature']) && in_array($_POST['feature'], $features, true)) ? $_POST['feature'] : '';
+$sub = $feature !== '' ? $feature . '/' : '';
+
+$uploadDir = __DIR__ . '/uploads/' . $sub;
+if (!is_dir($uploadDir) && !mkdir($uploadDir, 0755, true)) {
+    http_response_code(500);
+    header('Content-Type: application/json');
+    echo json_encode(['error' => 'Storage unavailable.']);
+    exit;
 }
 
-$name = bin2hex(random_bytes(16)) . '.' . $exts[$mime];
+// Owner-keyed name (u<id>_<random>) inside a namespaced folder, so provenance
+// is visible from the filename. The flat legacy path keeps its bare hash name.
+$rand = bin2hex(random_bytes(16));
+$name = ($feature !== '' ? 'u' . (int)$current['id'] . '_' : '') . $rand . '.' . $exts[$mime];
 $dest = $uploadDir . $name;
 
 if (!move_uploaded_file($file['tmp_name'], $dest)) {
@@ -99,7 +122,7 @@ if (!move_uploaded_file($file['tmp_name'], $dest)) {
     exit;
 }
 
-db_log_activity($current['id'], "uploaded image: $name");
+db_log_activity($current['id'], "uploaded image: $sub$name");
 
 header('Content-Type: application/json');
-echo json_encode(['url' => '/uploads/' . $name]);
+echo json_encode(['url' => '/uploads/' . $sub . $name]);

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2086');
+define('APP_VERSION', '0.2087');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
### Changed

**Uploads are namespaced by feature instead of one flat folder.** Every image landed in a single `/uploads/` directory as an anonymous `bin2hex().ext` file — avatars, post images, and ticket screenshots all mixed, with no way to tell them apart, attribute them, or clean them up.

`upload.php` now takes a **whitelisted** `feature` param (`avatars`/`posts`/`tickets`) — never free-form, so it can't traverse — routing into `/uploads/<feature>/` with owner-keyed names `u<id>_<random>.ext`. A request with no/unknown feature keeps the historical flat `/uploads/<hash>` path, so anything that doesn't opt in is unchanged.

Callers repointed: avatars (`settings.php`), post images (`admin_posts.php` + `league.php` Jodit uploaders), ticket screenshots (`support.php`, `support_ticket.php`). The site banner keeps its own separate fixed-name handler.

### Security

- **Uploads must decode as a real image.** Added a `getimagesize()` check on top of the byte-level MIME sniff.
- **Fixed three validators pinned to the old flat shape.** `set_avatar` (settings.php), `clean_screenshot` (support_dl.php), and `avatar_html` rendering (db.php) matched only `^/uploads/<32hex>.ext$` and would have silently rejected namespaced paths — now accept both legacy flat and namespaced `/uploads/<feature>/u<id>_…`. `sanitize_html` already allowed relative paths, so post images needed no change.

### Verification

End to end on dev (real UI uploads, admin account u1):
- avatar → `/uploads/avatars/u1_….png`, saves and renders in the nav
- post image → `/uploads/posts/u1_….jpg`
- ticket screenshot → `/uploads/tickets/u1_….jpg`
- legacy flat avatars still render; non-images and CSRF-less requests rejected

Shared-file regressions (db.php): double-dispatch sweep 557 controls, csp_nonce 29 — both clean. Pre-push parse + escaping sweeps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)