### PR TITLE
Timer BETA: video stream cell (v0.2111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2111] - 2026-08-26
+
+### Added
+
+- **Timer BETA: video stream cell — the classic timer's stream option, carried
+  over as a layout cell.** A cell may now hold `video: '<pasted URL>'` and
+  renders a streaming embed filling its flex box; in the editor, "Use a video
+  stream instead" sits beside the image / QR / chip-legend / seat-map
+  conversions (inspector and right-click menu both), with a Stream URL field
+  that validates through the renderer's own `normalizeStreamUrl` — ported
+  verbatim from `timer.js`, so both timers accept exactly the same links:
+  YouTube in every spelling (watch, youtu.be, embed, live, shorts, tv.),
+  Twitch channels (`parent=` filled from `location.hostname`, so one layout
+  works on dev and prod), Vimeo, Kick, a best-effort Prime pass-through, and
+  the admin "Allowed video stream hosts" setting (injected as
+  `TB_STREAM_HOSTS`). A link that will not survive Save warns in red as it is
+  typed.
+
+  Unlike the QR target (an enum), a video URL is author content in a shareable
+  document, so three fences guard it and each would hold alone:
+  `pk_lo_stream_url()` drops unrecognised hosts at save, the renderer only
+  ever loads `normalizeStreamUrl()`'s output (unknown hosts draw a dashed
+  `▶ video` placeholder, never an iframe), and the global CSP `frame-src`
+  lists the same hosts as the browser-enforced third copy. Video cells ride
+  the `isImage` flag so the text pass, empty-cell auto-hide and `capCell()`
+  leave the iframe alone, and the iframe is `pointer-events: none` in embed
+  mode only, so an editor-preview click selects the cell instead of vanishing
+  into the player. Trigger sounds duck the stream: `tbPlaySound()` postMessages
+  mute/unmute to YouTube and Vimeo embeds for a 5s window, honouring the
+  classic timer's `gn.muteStreamDuringAlarms` toggle so a device's choice
+  there carries over. Verified by a 12-point Playwright check
+  (`qa-headless/video_cell_check.js`): normalized-embed render, raw URL never
+  reaching the DOM, placeholder, conversion flow and save-side dropping.
+
+---
+
 ## [v0.2110] - 2026-08-25
 
 ### Fixed

--- a/TIMER_BETA.md
+++ b/TIMER_BETA.md
@@ -614,6 +614,57 @@ Three implementation notes worth keeping:
   src-less image renders as a broken-image glyph plus its alt text, which filled
   the editor preview with a white block.
 
+## Video cell — the classic timer's stream panel, as a cell
+
+`{ cell: { video: '<pasted URL>' } }` renders a streaming embed filling the
+box — the classic timer's "stream a video" option carried over. The layout
+stores the **raw pasted URL**; the renderer builds the actual embed through
+`normalizeStreamUrl()` (ported verbatim from `timer.js`, so both timers accept
+the same links): YouTube in every spelling (watch / youtu.be / embed / live /
+shorts / tv.), Twitch channels (`parent=` is filled from `location.hostname`,
+so the same layout works on localhost and prod), Vimeo, Kick, a best-effort
+Prime pass-through, plus the admin-allowlisted hosts from Settings → General
+(injected as `TB_STREAM_HOSTS`).
+
+Unlike the QR target (an enum), a video URL is author content in a shareable
+document. Three fences keep that safe, and each would hold alone:
+
+- `pk_lo_stream_url()` in the sanitizer drops any URL whose host isn't on the
+  recognised list at save;
+- the renderer's `normalizeStreamUrl()` returns `''` for unknown hosts at
+  paint, and the iframe only ever loads its output — an unrecognised URL draws
+  the dashed `▶ video` placeholder (same idea as `tb-qr-empty`), never an
+  embed;
+- the global CSP `frame-src` (auth.php) lists the same hosts, so the browser
+  refuses anything that somehow slipped both.
+
+Keep the three lists in step: `normalizeStreamUrl` (timer_beta.js),
+`pk_lo_stream_url` (timer_beta_dl.php), and the CSP frame-src + admin extras
+(auth.php / `stream_allowed_hosts()`).
+
+Implementation notes, all inherited from the QR cell's lessons:
+
+- A video cell sets `isImage` on its record — the text pass would otherwise
+  wipe the iframe on the first tick, and the empty-cell auto-hide would hide
+  it. `capCell()` skips it for the same reason.
+- The iframe gets `pointer-events: none` in embed mode only, so a click in the
+  editor preview selects the cell instead of vanishing into the player.
+  On a live display the player keeps its controls.
+- Trigger sounds duck the stream: `tbPlaySound()` calls
+  `tbMuteStreamForAlarm(5000)`, which postMessages mute/unmute to YouTube and
+  Vimeo embeds (the only hosts with a message API — Twitch/Kick/Prime keep
+  playing, same as the classic timer). It honours the classic timer's
+  `gn.muteStreamDuringAlarms` localStorage toggle, default on, so a device's
+  choice there carries over here.
+
+**Editor**: "Use a video stream instead" beside the other conversions sets
+`video: ''` — the cell shows the placeholder until a link is pasted into the
+inspector's Stream URL field, which validates through
+`TBPreview.normalizeStreamUrl` (the renderer's own function, same contract as
+`validateCondition`) and warns in red when a link won't survive Save. An empty
+or unrecognised URL is dropped by the sanitizer on Save and the cell reverts
+to text.
+
 ## What a scanned screen may read
 
 A screen opened with `?key=` must render **the layout the host chose**, and it

--- a/www/timer_beta.css
+++ b/www/timer_beta.css
@@ -190,6 +190,17 @@ body.tb-letterbox { background: #000; }
 .tb-img { max-width: 100%; max-height: 100%; object-fit: contain; }
 .tb-img-cover { width: 100%; height: 100%; object-fit: cover; }
 
+/* Streaming video cell: the iframe fills its flex box — the box's size and
+   weight ARE the video's size, same rule as every other cell. */
+.tb-cell-video .tb-cell-inner { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; }
+.tb-video { width: 100%; height: 100%; border: 0; background: #000; }
+/* No URL (or an unrecognised one): the dashed footprint, same idea as the
+   QR placeholder — the editor must see where the cell sits, never a blank. */
+.tb-cell-video.tb-video-empty .tb-cell-inner::after {
+    content: '\25B6 video'; font-size: 1.6vh; letter-spacing: .1em; color: #64748b;
+    border: 1px dashed currentColor; border-radius: 4px; padding: 1.2vh 1.6vh;
+}
+
 /* Clock state colours; the layout's own colour applies until a state does. */
 .tb-warn   { color: #fbbf24 !important; }
 .tb-crit   { color: #ef4444 !important; }

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -689,10 +689,55 @@ var soundHook = null;   // QA observation point — set via TBPreview, embed onl
 // Editor preview only: pretend to be this device class ('mobile'/'tablet'/
 // 'desktop', null = honest detection). Set via TBPreview.device().
 var deviceOverride = null;
+/* ── Stream mute during trigger sounds ────────────────────────────────────
+ * Ported from the classic timer (§7.15.1): postMessage mute/unmute to
+ * YouTube / Vimeo embeds so a streaming cell doesn't drown out an alarm.
+ * Other hosts (Twitch, Kick, Prime) expose no message API — they simply
+ * keep playing, same as the classic timer. Honours the same localStorage
+ * toggle ('gn.muteStreamDuringAlarms', default ON) so a device's choice on
+ * the classic timer carries over here. */
+var STREAM_MUTED_BY_ALARM = false;
+var STREAM_UNMUTE_TIMER = null;
+function tbStreamMute(on) {
+    videoFrames.forEach(function (frame) {
+        if (!frame.isConnected || !frame.src) return;
+        try {
+            var host = new URL(frame.src).hostname;
+            if (/youtube/.test(host)) {
+                frame.contentWindow.postMessage(JSON.stringify({
+                    event: 'command', func: on ? 'mute' : 'unMute', args: []
+                }), '*');
+            } else if (/vimeo/.test(host)) {
+                frame.contentWindow.postMessage(JSON.stringify({
+                    method: 'setMuted', value: !!on
+                }), '*');
+            }
+        } catch (e) {}
+    });
+}
+function tbMuteStreamForAlarm(durationMs) {
+    if (!videoFrames.length) return;
+    try {
+        if (localStorage.getItem('gn.muteStreamDuringAlarms') === 'false') return;
+    } catch (e) {}
+    tbStreamMute(true);
+    STREAM_MUTED_BY_ALARM = true;
+    if (STREAM_UNMUTE_TIMER) clearTimeout(STREAM_UNMUTE_TIMER);
+    STREAM_UNMUTE_TIMER = setTimeout(function () {
+        if (STREAM_MUTED_BY_ALARM) { tbStreamMute(false); STREAM_MUTED_BY_ALARM = false; }
+        STREAM_UNMUTE_TIMER = null;
+    }, durationMs);
+}
+
 function tbPlaySound(val) {
     if (!soundOn) return;
     if (typeof val !== 'string') return;
     if (soundHook) { soundHook(val); return; }   // heard, not played
+    // Duck any streaming cells while the sound plays. Presets run ~1-2s and
+    // uploaded sounds are capped short; a flat 5s window (sound + padding)
+    // matches the classic timer's per-alarm windows without tracking each
+    // sound's real length. Reentrant — an overlapping sound extends the mute.
+    tbMuteStreamForAlarm(5000);
     if (val.indexOf('preset:') === 0) {
         var segs = TB_PRESETS[val.slice(7)];
         if (!segs) return;
@@ -1126,6 +1171,7 @@ var qrCells  = [];   // cells rendering a QR code
 var chipCells = [];  // cells rendering the chip legend
 var seatCells = [];  // cells rendering the final-table seat map
 var clockCells = []; // cells whose colour tracks warn/critical
+var videoFrames = []; // live streaming <iframe>s — the alarm mute walks these
 
 function applyBox(el, node) {
     if (node.weight !== undefined) { el.style.flexGrow = String(node.weight); el.style.flexBasis = '0'; }
@@ -1285,6 +1331,92 @@ function safeImageSrc(v) {
          || /^\/img\/timer_beta\/[a-z0-9._-]{1,80}$/.test(v)) ? v : null;
 }
 
+// Normalize a user-pasted streaming URL into a safe embed URL — the classic
+// timer's normalizeStreamUrl, ported verbatim so the two timers accept the
+// same links. Returns '' for anything unrecognised so the iframe stays blank
+// (dashed placeholder) rather than loading an arbitrary cross-origin page.
+// The server sanitizer (pk_lo_stream_url) enforces the same host list on
+// save; the global CSP frame-src is the third, browser-enforced copy. Twitch
+// needs a parent= matching the embedding hostname — sourced from
+// location.hostname so it works in dev (localhost) and prod without settings.
+function normalizeStreamUrl(raw) {
+    if (!raw) return '';
+    raw = String(raw).trim();
+    var u;
+    try { u = new URL(raw); } catch (e) { return ''; }
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return '';
+    var h = u.hostname.replace(/^www\./, '').toLowerCase();
+    // YouTube — full watch URL, short youtu.be, embed/, live/, shorts/.
+    // `?enablejsapi=1` lets this page postMessage mute/unmute commands —
+    // used by the alarm-mute feature.
+    var YT = 'https://www.youtube-nocookie.com/embed/';
+    var YT_PARAMS = '?enablejsapi=1';
+    if (h === 'youtube.com' || h === 'm.youtube.com' || h === 'music.youtube.com') {
+        var v = u.searchParams.get('v');
+        if (v) return YT + encodeURIComponent(v) + YT_PARAMS;
+        var m = u.pathname.match(/^\/(?:embed|live|shorts)\/([\w-]{6,})/);
+        if (m) return YT + m[1] + YT_PARAMS;
+    }
+    if (h === 'youtu.be') {
+        var id = u.pathname.replace(/^\//, '').split('/')[0];
+        if (id) return YT + encodeURIComponent(id) + YT_PARAMS;
+    }
+    // YouTube TV — try the /watch/<id> as a regular embed; live/subscription
+    // content won't play inside the iframe, but shared VOD will.
+    if (h === 'tv.youtube.com') {
+        var mtv = u.pathname.match(/^\/watch\/([\w-]{6,})/);
+        if (mtv) return YT + mtv[1] + YT_PARAMS;
+    }
+    if (h === 'youtube-nocookie.com') {
+        if (raw.indexOf('enablejsapi=') === -1) {
+            return raw + (raw.indexOf('?') === -1 ? '?' : '&') + 'enablejsapi=1';
+        }
+        return raw;
+    }
+    // Twitch — first path segment is the channel name.
+    if (h === 'twitch.tv') {
+        var ch = u.pathname.replace(/^\//, '').split('/')[0];
+        if (ch) return 'https://player.twitch.tv/?channel=' + encodeURIComponent(ch)
+            + '&parent=' + encodeURIComponent(location.hostname || 'localhost');
+    }
+    if (h === 'player.twitch.tv') {
+        u.searchParams.set('parent', location.hostname || 'localhost');
+        return u.toString();
+    }
+    // Vimeo — extract the numeric video ID and use player.vimeo.com.
+    if (h === 'vimeo.com') {
+        var vparts = u.pathname.split('/').filter(Boolean);
+        for (var vi = vparts.length - 1; vi >= 0; vi--) {
+            if (/^\d{5,}$/.test(vparts[vi])) {
+                return 'https://player.vimeo.com/video/' + vparts[vi];
+            }
+        }
+    }
+    if (h === 'player.vimeo.com') return raw;
+    // Kick — channel URL; embed lives at player.kick.com/<channel>.
+    if (h === 'kick.com') {
+        var kch = u.pathname.replace(/^\//, '').split('/')[0];
+        if (kch) return 'https://player.kick.com/' + encodeURIComponent(kch);
+    }
+    if (h === 'player.kick.com') return raw;
+    // Prime Video — best-effort pass-through; Amazon usually refuses framing.
+    if (h === 'primevideo.com' || h === 'amazon.com' || h.endsWith('.amazon.com')) {
+        return raw;
+    }
+    // Admin-allowlisted custom hosts (Settings → General). Forced to https —
+    // an http embed would be mixed-content blocked. Must stay in sync with
+    // the CSP frame-src built in auth.php.
+    var rawHost = u.hostname.toLowerCase();
+    var extra = window.TB_STREAM_HOSTS || [];
+    for (var ei = 0; ei < extra.length; ei++) {
+        var pat = String(extra[ei]).toLowerCase();
+        var hit = (pat.indexOf('*.') === 0) ? rawHost.endsWith(pat.slice(1)) : (rawHost === pat);
+        if (hit) { u.protocol = 'https:'; return u.toString(); }
+    }
+    // Unknown host — render nothing (safer than allowing arbitrary embeds).
+    return '';
+}
+
 function buildCell(spec) {
     var el = document.createElement('div');
     el.className = 'tb-cell';
@@ -1336,6 +1468,35 @@ function buildCell(spec) {
         qrCells.push({ el: el, img: qimg, target: spec.qr, drawn: null });
     }
 
+    // Streaming video cell: an <iframe> filling the box — the classic timer's
+    // stream panel as a layout cell. The layout stores the RAW pasted URL;
+    // the iframe only ever loads what normalizeStreamUrl() built from it, so
+    // an unrecognised host draws the dashed placeholder instead of an embed
+    // (CSP frame-src would refuse it anyway — belt and braces). The src is an
+    // attribute assignment, never innerHTML.
+    if ('video' in spec) {
+        el.classList.add('tb-cell-video');
+        var vSrc = normalizeStreamUrl(spec.video);
+        if (vSrc) {
+            var ifr = document.createElement('iframe');
+            ifr.className = 'tb-video';
+            ifr.src = vSrc;
+            ifr.setAttribute('frameborder', '0');
+            ifr.setAttribute('allow', 'autoplay; encrypted-media; picture-in-picture; fullscreen');
+            ifr.setAttribute('allowfullscreen', '');
+            // In the editor preview the iframe must not swallow the click
+            // that selects its cell (direct manipulation) — and nobody
+            // operates the video from inside the editor anyway.
+            if (window.TB_EMBED) ifr.style.pointerEvents = 'none';
+            inner.appendChild(ifr);
+            videoFrames.push(ifr);
+        } else {
+            // No/unrecognised URL: a visible stub, same idea as tb-qr-empty —
+            // the editor needs to see the cell's footprint, never a blank.
+            el.classList.add('tb-video-empty');
+        }
+    }
+
     // Structural / base-only styling, set once.
     if (spec.fit) el.classList.add('tb-fit');
     else el.style.fontSize = (spec.size || 2.4) + 'vh';
@@ -1360,7 +1521,7 @@ function buildCell(spec) {
     if (spec.clockColors) clockCells.push(el);
 
     var rec = {
-        el: el, inner: inner, spec: spec, isImage: !!imgSrc || !!spec.qr || !!spec.chips || !!spec.seats,
+        el: el, inner: inner, spec: spec, isImage: !!imgSrc || !!spec.qr || !!spec.chips || !!spec.seats || ('video' in spec),
         variants: Array.isArray(spec.variants) ? spec.variants : [],
         elSpans: [], lastText: null, lastVariant: -2, isFit: !!spec.fit
     };
@@ -1465,7 +1626,7 @@ function buildScreen(idx) {
         ? CURRENT_LAYOUT.styles : {};
     rebuildElementIndex();
     var screen = CURRENT_LAYOUT.screens[idx] || { root: { col: [] } };
-    fitCells = []; clockCells = []; allCells = []; whenBoxes = []; qrCells = []; chipCells = []; seatCells = [];
+    fitCells = []; clockCells = []; allCells = []; whenBoxes = []; qrCells = []; chipCells = []; seatCells = []; videoFrames = [];
     root.textContent = '';
     root.style.background = '';
     root.style.backgroundImage = '';
@@ -2281,6 +2442,10 @@ if (window.TB_EMBED) {
             var c = compileCond(t);
             return { ok: !!c.fn, error: c.error };
         },
+        // Streaming-URL check: the editor validates a pasted link through the
+        // renderer's own normalizer (same reason as validateCondition — the
+        // tick the author sees and what the display loads can never disagree).
+        normalizeStreamUrl: function (raw) { return normalizeStreamUrl(raw); },
         conditionNames: function () { return COND_NAMES.slice(); },
         // Trigger "Test" button: run an action list right now, ignoring
         // when/cooldown/once — auditioning, not simulating.

--- a/www/timer_beta.php
+++ b/www/timer_beta.php
@@ -182,6 +182,9 @@ var TB_CAST_KEY = <?= json_encode($cast_key ?: null) ?>;
 var TB_EVENT_TITLE = <?= json_encode($event_title) ?>;
 var TB_EMBED       = <?= json_encode($is_embed) ?>;
 var TB_EVENT_LAYOUT_ID = <?= json_encode($event_layout_id) ?>;
+// Admin-configured extra stream hosts for video cells (mirrors the CSP
+// frame-src allowlist built in auth.php, same as the classic timer's page).
+var TB_STREAM_HOSTS = <?= json_encode(stream_allowed_hosts()) ?>;
 var TB_EVENT_LAYOUT_KEY = <?= json_encode($event_layout_key) ?>;
 </script>
 <?php if (!$is_embed): ?>

--- a/www/timer_beta_dl.php
+++ b/www/timer_beta_dl.php
@@ -91,6 +91,39 @@ function pk_lo_num($v, float $min, float $max): ?float {
     if (!is_numeric($v)) return null;
     return max($min, min($max, (float)$v));
 }
+/**
+ * A cell's streaming-video URL. The RAW pasted URL is stored, but only when it
+ * belongs to a recognised streaming service (or an admin-allowlisted host) —
+ * the same acceptance rule as `normalizeStreamUrl()` in timer_beta.js, which
+ * builds the actual embed URL at render time. Mirror the two lists; a URL that
+ * passes here but not there renders as the dashed placeholder, never as an
+ * arbitrary iframe. Unknown hosts return null so the sanitizer drops the key:
+ * a layout is a shareable document, and unlike the QR target (an enum) a video
+ * URL is author content — this host gate plus the global CSP frame-src is what
+ * keeps a shared layout from embedding an attacker's page on a wall of screens.
+ */
+function pk_lo_stream_url($v): ?string {
+    if (!is_string($v)) return null;
+    $v = trim($v);
+    if ($v === '' || strlen($v) > 500) return null;
+    $p = parse_url($v);
+    if (!$p || !in_array(strtolower($p['scheme'] ?? ''), ['http', 'https'], true)) return null;
+    $h = strtolower($p['host'] ?? '');
+    if ($h === '') return null;
+    $bare = preg_replace('/^www\./', '', $h);
+    $known = ['youtube.com', 'm.youtube.com', 'music.youtube.com', 'tv.youtube.com',
+              'youtu.be', 'youtube-nocookie.com',
+              'twitch.tv', 'player.twitch.tv',
+              'vimeo.com', 'player.vimeo.com',
+              'kick.com', 'player.kick.com',
+              'primevideo.com', 'amazon.com'];
+    if (in_array($bare, $known, true) || str_ends_with($h, '.amazon.com')) return $v;
+    foreach (stream_allowed_hosts() as $pat) {
+        $hit = (strpos($pat, '*.') === 0) ? str_ends_with($h, substr($pat, 1)) : ($h === $pat);
+        if ($hit) return $v;
+    }
+    return null;
+}
 
 /* Validates a condition expression against the SAME grammar the renderer
  * compiles ("bigBlind > 10000 and not onBreak"). The string is stored verbatim
@@ -215,6 +248,9 @@ function pk_lo_cell($cell, array &$err): ?array {
     // target against the session's own remote_key; nothing from this file
     // reaches the scanner.
     if (isset($cell['qr']) && in_array($cell['qr'], ['display'], true)) $out['qr'] = $cell['qr'];
+    // Streaming video: the raw URL, kept only for recognised services (the
+    // renderer normalizes it into the actual embed URL — see pk_lo_stream_url).
+    if (isset($cell['video'])) { $v = pk_lo_stream_url($cell['video']); if ($v !== null) $out['video'] = $v; }
     // Chip legend. A flag, not content: the denominations come from the game,
     // never from the layout file.
     if (!empty($cell['chips'])) $out['chips'] = true;

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -361,6 +361,7 @@ var treeEl = document.getElementById('tbeTree');
 var treeCollapsed = {};
 
 function cellLabel(cell) {
+    if (cell.video !== undefined) return '(video stream)';
     var t = String(cell.text || '').replace(/\n/g, ' ').trim();
     return t.length > 26 ? t.slice(0, 26) + '…' : (t || '(empty cell)');
 }
@@ -1586,6 +1587,47 @@ function renderInspector() {
             return;
         }
 
+        // Streaming video cell: a pasted YouTube / Twitch / Vimeo / Kick link
+        // rendered as an embed filling the box. The raw URL is stored; the
+        // display builds the embed through the renderer's normalizeStreamUrl
+        // (validated here through the same function, so the tick the author
+        // sees and what a display loads can never disagree), and the save-side
+        // sanitizer drops unrecognised hosts.
+        if (cell.video !== undefined) {
+            var vWrap = document.createElement('div');
+            vWrap.className = 'tbe-field';
+            var vl = document.createElement('span'); vl.textContent = 'Video stream'; vWrap.appendChild(vl);
+            var vn = document.createElement('div'); vn.className = 'tbe-note';
+            vn.textContent = 'Paste a YouTube, Twitch, Vimeo or Kick link. The video fills this cell — '
+                           + 'give the box more weight for a bigger picture. YouTube and Vimeo mute '
+                           + 'themselves while alarm sounds play.';
+            vWrap.appendChild(vn);
+            insp.appendChild(vWrap);
+            var vu = document.createElement('input');
+            vu.type = 'text'; vu.placeholder = 'https://www.youtube.com/watch?v=…';
+            vu.value = cell.video || '';
+            var vErr = document.createElement('div'); vErr.className = 'tbe-note';
+            var vCheck = function () {
+                var raw = vu.value.trim();
+                var ok = raw !== '' && PV && PV.normalizeStreamUrl && PV.normalizeStreamUrl(raw) !== '';
+                vu.style.borderColor = (raw === '' || ok) ? '' : '#ef4444';
+                vErr.textContent = raw === '' ? 'No link yet — the cell shows a placeholder until one is pasted.'
+                                 : ok ? '' : 'Not a recognised streaming link — the display will show a placeholder and Save will drop it.';
+            };
+            vu.addEventListener('input', vCheck);
+            vu.addEventListener('change', function () { pushUndo(); cell.video = vu.value.trim(); refresh(true); vCheck(); });
+            vCheck();
+            insp.appendChild(field('Stream URL', vu));
+            insp.appendChild(vErr);
+            insp.appendChild(field('Weight (share of space)', numInput(node.weight, 0, 50, 0.1, function (v) { setOrDelete(node, 'weight', v); })));
+            insp.appendChild(field('Show when', condEditor(cell.when, function (v) { pushUndo(); setOrDelete(cell, 'when', v); refresh(true); })));
+            var rmV = document.createElement('button'); rmV.className = 'tbe-mini tbe-mini-danger';
+            rmV.textContent = 'Remove video (back to text)';
+            rmV.addEventListener('click', function () { pushUndo(); delete cell.video; refresh(true); renderInspector(); });
+            insp.appendChild(rmV);
+            return;
+        }
+
         var toImg = document.createElement('button');
         toImg.className = 'tbe-mini'; toImg.textContent = 'Use an image instead';
         toImg.addEventListener('click', function () { uploadImage(function (url) { pushUndo(); cell.image = url; refresh(true); renderInspector(); }); });
@@ -1608,6 +1650,12 @@ function renderInspector() {
         toSeats.title = 'The final table: every remaining player at their assigned seat';
         toSeats.addEventListener('click', function () { pushUndo(); cell.seats = true; refresh(true); renderInspector(); });
         insp.appendChild(toSeats);
+
+        var toVid = document.createElement('button');
+        toVid.className = 'tbe-mini'; toVid.textContent = 'Use a video stream instead';
+        toVid.title = 'Embed a YouTube / Twitch / Vimeo / Kick video in this cell';
+        toVid.addEventListener('click', function () { pushUndo(); cell.video = ''; refresh(true); renderInspector(); });
+        insp.appendChild(toVid);
 
         var ta = document.createElement('textarea');
         ta.rows = 3; ta.value = cell.text || '';
@@ -1957,6 +2005,8 @@ function openNodeMenu(path, x, y) {
             item('Remove chip legend (back to text)', edit(function () { delete cell.chips; }));
         } else if (cell.seats) {
             item('Remove seat map (back to text)', edit(function () { delete cell.seats; delete cell.table; }));
+        } else if (cell.video !== undefined) {
+            item('Remove video (back to text)', edit(function () { delete cell.video; }));
         } else {
             toggle('Bold', !!cell.bold, edit(function () { setOrDelete(cell, 'bold', cell.bold ? undefined : true); }));
             toggle('Fit text to box', !!cell.fit, edit(function () { setOrDelete(cell, 'fit', cell.fit ? undefined : true); }));
@@ -1993,6 +2043,7 @@ function openNodeMenu(path, x, y) {
             item('Use a QR code instead', edit(function () { cell.qr = 'display'; }));
             item('Use a chip legend instead', edit(function () { cell.chips = true; }));
             item('Use a seat map instead', edit(function () { cell.seats = true; }));
+            item('Use a video stream instead', edit(function () { cell.video = ''; }));
         }
         // Box properties apply whatever the cell holds.
         sub('Background', colourPanel(cell.bg, function (v) { setOrDelete(cell, 'bg', v); }, 'None'));

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2110');
+define('APP_VERSION', '0.2111');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
The classic timer's "stream a video" option, carried over to the BETA layout engine as a cell type.

A cell may now hold `video: '<pasted URL>'` and renders a streaming embed filling its flex box — size it by weight like any other cell. In the editor, **"Use a video stream instead"** sits beside the image / QR / chip-legend / seat-map conversions (inspector and right-click menu), with a Stream URL field validated through the renderer's own `normalizeStreamUrl` — ported verbatim from `timer.js`, so both timers accept exactly the same links: YouTube in every spelling (watch, youtu.be, embed, live, shorts, tv.), Twitch channels (`parent=` filled from `location.hostname`, so one layout works on dev and prod), Vimeo, Kick, best-effort Prime pass-through, and the admin "Allowed video stream hosts" setting (injected as `TB_STREAM_HOSTS`). A link that won't survive Save warns in red as it is typed, and the structure tree labels the cell `(video stream)`.

## Why the URL is fenced three ways

Unlike the QR target (an enum), a video URL is author content in a shareable document. Three fences, each sufficient alone:

- `pk_lo_stream_url()` in the sanitizer drops any URL whose host isn't recognised at save;
- the renderer only ever loads `normalizeStreamUrl()`'s output — an unknown host draws the dashed `▶ video` placeholder, never an iframe;
- the global CSP `frame-src` (auth.php) lists the same hosts, browser-enforced.

## Inherited from the QR cell's lessons

- Video cells ride the `isImage` flag, so the text pass, empty-cell auto-hide and `capCell()` leave the iframe alone.
- The iframe is `pointer-events: none` **in embed mode only**, so an editor-preview click selects the cell instead of vanishing into the player; a live display keeps the player's controls.
- Trigger sounds duck the stream: `tbPlaySound()` postMessages mute/unmute to YouTube and Vimeo embeds for a 5s window (the only hosts with a message API — Twitch/Kick/Prime keep playing, same as the classic timer), honouring the classic timer's `gn.muteStreamDuringAlarms` localStorage toggle.

## Verified on dev

- Sanitizer round-trip: YouTube URL kept; `evil.example.com`, `javascript:` and empty URLs dropped; text cells untouched.
- Inline-JS sweep: 23 pages, 0 broken blocks. Full PHP parse sweep, known-bad-escaping and declarative-markup greps clean.
- New 12-point Playwright check (`qa-headless/video_cell_check.js`): display renders exactly one iframe with the **normalized** nocookie embed (`enablejsapi=1` present, raw pasted URL never reaches the DOM), Twitch normalization carries `parent=<host>`, editor conversion/placeholder/red-warning flow all behave.
- User-confirmed on the dev instance with a real layout ("Watch Party": stream panel + clock/blinds column + stats bar), including YouTube's graceful in-player error for a non-embeddable video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)