### PR TITLE
Legacy preset guard: no more silent schedule-less tournaments (v0.2112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2112] - 2026-08-26
+
+### Fixed
+
+- **Loading a legacy Setup preset no longer leaves a tournament silently
+  schedule-less.** A preset saved before v0.2089 predates blind schedules
+  traveling with presets (`blind_levels` NULL = legacy), and loading one
+  restored payouts and game config while leaving the timer with no schedule at
+  all — the host found out at the table, when the board read 0/0 and the clock
+  stopped dead at the end of level 1. Three guards now stand, each at the
+  moment its audience can act: `load_payout_structure` answers
+  `no_blinds: true` when the loaded structure brought no schedule and the
+  game's timer still has none (cash games excluded — no blind clock to
+  starve); Setup surfaces that as an alert on load, pointing at the Blinds tab
+  and noting that **Update preset** afterwards stores the schedule in the
+  preset for good; and the BETA display renders '&mdash;' for blinds instead
+  of a confident-looking 0/0 on a live game with an empty schedule, with an
+  amber banner — visible only to a viewer who can control the game — saying
+  what is wrong and where to fix it. Guests and cast screens see the quiet
+  dashes; sample mode and the editor preview are untouched. Verified by
+  `qa-headless/noblinds_check.js` plus load-path round-trips both ways.
+
+---
+
 ## [v0.2111] - 2026-08-26
 
 ### Added

--- a/www/checkin.php
+++ b/www/checkin.php
@@ -3511,6 +3511,14 @@ function loadPayoutStructure() {
         .then(function(j) {
             pkProgressDone();
             if (!j.ok) { pkAlert(j.error || 'Error'); return; }
+            // Legacy preset (pre-v0.2089): it carried no blind schedule and this
+            // game's timer has none either. Warn here, in Setup, rather than
+            // letting the host discover 0/0 blinds mid-game.
+            if (j.no_blinds) {
+                pkAlert('This preset was saved before blind schedules traveled with presets, so it brought no blinds along.\n\n'
+                      + 'Open the Blinds tab and pick a schedule before game time — without one the timer has nothing to count through. '
+                      + 'Saving the preset again afterwards (Update preset) stores the schedule in it for good.');
+            }
             PAYOUTS = j.payouts;
             POOL = j.pool || POOL;
             if (j.session) SESSION = j.session;  // recipe presets update bounty/jackpot too

--- a/www/checkin_dl.php
+++ b/www/checkin_dl.php
@@ -2039,18 +2039,32 @@ if ($action === 'load_payout_structure') {
 
     $sess2 = $db->prepare('SELECT * FROM poker_sessions WHERE id = ?');
     $sess2->execute([$session_id]);
+    $sessRow = $sess2->fetch();
 
     // Current timer flags so the client can retarget the Timer button and
     // refresh the Blinds pane without another round-trip.
-    $tq2 = $db->prepare('SELECT use_beta FROM timer_state WHERE session_id = ?');
+    $tq2 = $db->prepare('SELECT use_beta, preset_id FROM timer_state WHERE session_id = ?');
     $tq2->execute([$session_id]);
+    $trow2 = $tq2->fetch() ?: [];
+
+    // Legacy-preset guard: a structure saved before v0.2089 carries no blind
+    // schedule ("NULL = legacy"), and applying one used to leave a tournament
+    // timer schedule-less in silence — the host found out at the table, when
+    // the board read 0/0 and the clock had nothing to advance into. If the
+    // loaded structure brought no blinds AND the game's timer still has no
+    // schedule of its own, say so NOW, while the host is in Setup with the
+    // Blinds tab one click away. Cash games have no blind clock to starve.
+    $no_blinds = empty($struct['blind_levels'])
+        && !(int)($trow2['preset_id'] ?? 0)
+        && (($sessRow['game_type'] ?? '') !== 'cash');
 
     echo json_encode([
         'ok'      => true,
-        'session' => $sess2->fetch(),
+        'session' => $sessRow,
         'payouts' => get_payouts($db, $session_id),
         'pool'    => calc_pool($db, $session_id),
-        'use_beta' => (int)($tq2->fetchColumn() ?: 0),
+        'use_beta' => (int)($trow2['use_beta'] ?? 0),
+        'no_blinds' => $no_blinds,
     ]);
     exit;
 }

--- a/www/timer_beta.css
+++ b/www/timer_beta.css
@@ -204,6 +204,15 @@ body.tb-letterbox { background: #000; }
 /* Clock state colours; the layout's own colour applies until a state does. */
 .tb-warn   { color: #fbbf24 !important; }
 .tb-crit   { color: #ef4444 !important; }
+
+/* No-blind-schedule banner: amber = warning (house rule), shown only to a
+   viewer who can control the game. Fixed over the layout, never part of it. */
+#tbNoBlinds {
+    position: fixed; left: 50%; bottom: 2.5vh; transform: translateX(-50%);
+    background: #fffbeb; color: #92400e; border: 1px solid #f59e0b;
+    border-radius: 8px; padding: 1vh 1.6vw; font-size: 1.9vh; font-weight: 600;
+    z-index: 60; box-shadow: 0 0.6vh 2vh rgba(0,0,0,.45); max-width: 90vw; text-align: center;
+}
 .tb-paused { opacity: 0.55; animation: tbPulse 2.2s ease-in-out infinite; }
 @keyframes tbPulse { 50% { opacity: 0.3; } }
 @media (prefers-reduced-motion: reduce) { .tb-paused { animation: none; } }

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -462,10 +462,13 @@ var ELEMENTS = {
     clock:        function () { return fmtClock(liveRemaining()); },
     gameName:     function () { return S.isBreak ? 'BREAK' : "No Limit Texas Hold 'Em"; },
     nextGameName: function () { return S.nextIsBreak ? 'Break' : "No Limit Texas Hold 'Em"; },
-    smallBlind:   function () { return fmtChips(S.sb); },
-    bigBlind:     function () { return fmtChips(S.bb); },
+    smallBlind:   function () { return S.noSchedule ? '—' : fmtChips(S.sb); },
+    bigBlind:     function () { return S.noSchedule ? '—' : fmtChips(S.bb); },
     ante:         function () { return S.ante ? fmtChips(S.ante) : '-'; },
-    blinds:       function () { return S.isBreak ? 'On Break' : fmtChips(S.sb) + ' / ' + fmtChips(S.bb); },
+    blinds:       function () {
+        if (S.noSchedule) return '—';
+        return S.isBreak ? 'On Break' : fmtChips(S.sb) + ' / ' + fmtChips(S.bb);
+    },
     nextBlinds:   function () {
         if (S.nsb === null) return '-';
         if (S.nextIsBreak) return 'Break';
@@ -2128,6 +2131,11 @@ function drawQrCells() {
 
 function refreshDerived() {
     var cur = findLevel(S.level), nxt = findLevel(S.level + 1);
+    // A LIVE game with an empty schedule: the timer has no blind preset, so
+    // there are no numbers to show and no level to advance into. Flagged so
+    // the blinds elements render '—' instead of a confident-looking 0/0, and
+    // so the controller banner can say what is actually wrong.
+    S.noSchedule = !S.sample && S.levels.length === 0;
     S.isBreak = !!(cur && (cur.is_break | 0));
     S.sb = cur ? cur.small_blind : 0;
     S.bb = cur ? cur.big_blind : 0;
@@ -2266,9 +2274,29 @@ function poll() {
             CAN_CONTROL = !!j.can_control;
             if (j.csrf_token) CSRF = j.csrf_token;
             refreshDerived();
+            updateNoBlindsBanner();
             updateAll();
         })
         .catch(function () { /* transient network errors: keep ticking on last state */ });
+}
+
+/* ── No-schedule banner ───────────────────────────────────────────────────
+ * A live game whose timer has no blind preset shows '—' blinds (see
+ * refreshDerived) — but only someone who can FIX it gets told why. Guests and
+ * cast screens see the quiet dashes; the host sees the amber banner. Built in
+ * JS rather than the page so the editor's embed preview (sample data, no
+ * session) can never grow one. */
+function updateNoBlindsBanner() {
+    if (window.TB_EMBED) return;
+    var el = document.getElementById('tbNoBlinds');
+    var want = !!(S.noSchedule && CAN_CONTROL);
+    if (want && !el) {
+        el = document.createElement('div');
+        el.id = 'tbNoBlinds';
+        el.textContent = 'This game has no blind schedule — pick one in Setup → Blinds, then reload this display.';
+        document.body.appendChild(el);
+    }
+    if (el) el.style.display = want ? '' : 'none';
 }
 
 // Whether keyboard control is live: a real event session, the viewer can

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2111');
+define('APP_VERSION', '0.2112');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
A Setup preset saved before v0.2089 predates blind schedules traveling with presets (`blind_levels` NULL = legacy). Loading one restored payouts and game config while leaving the timer with no schedule — the host found out at the table, when the board read 0/0 and the clock stopped dead at the end of level 1. That is exactly how event 196 went down on Aug 26.

Three guards, each at the moment its audience can act:

- **Server**: `load_payout_structure` answers `no_blinds: true` when the loaded structure brought no schedule AND the game's timer still has none. Cash games are excluded — no blind clock to starve. A schedule-carrying preset applies its blinds and answers `false`.
- **Setup**: that flag becomes an alert the moment the host loads a legacy preset — pick a schedule in the Blinds tab, and **Update preset** afterwards stores it in the preset for good (self-service version of the manual repair done for "Snowman - Free Play").
- **Display**: the BETA timer renders `—` for blinds instead of a confident-looking 0/0 on a live game with an empty schedule (`S.noSchedule` in `refreshDerived()`), and a viewer with control rights gets an amber banner: *"This game has no blind schedule — pick one in Setup → Blinds, then reload this display."* Guests and cast screens see only the quiet dashes. Sample mode and the editor's embed preview can never grow the banner.

## Verified on dev

- Load-path round-trips both ways: legacy structure → `no_blinds: true`; after backfilling the same structure with levels → blinds applied (session-scoped preset created, timer wired) and `no_blinds: false`.
- Browser check (`qa-headless/noblinds_check.js`): dashes render, no "0 / 0" anywhere on the page, banner visible to the host, absent in sample mode.
- Inline-JS sweep clean across all 23 pages (checkin.php's generated JS was touched), full PHP parse sweep, known-bad-escaping and declarative-markup greps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)