### PR TITLE
Timer BETA: play from a Plex library (draft, untested against a real server)

### DIFF
--- a/www/admin_settings.php
+++ b/www/admin_settings.php
@@ -199,6 +199,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Extra hosts the timer streaming panel may embed. Store raw; it is
                 // strictly re-validated on read by stream_allowed_hosts() before use.
                 set_setting('stream_allowed_hosts', trim($_POST['stream_allowed_hosts'] ?? ''));
+                // Plex Media Server (Timer BETA video cell). The token is write-only
+                // from this form: submitted blank it keeps whatever is stored, so the
+                // value never has to be echoed back into the page to be edited.
+                set_setting('plex_url', trim($_POST['plex_url'] ?? ''));
+                if (!empty($_POST['plex_token_clear'])) {
+                    set_setting('plex_token', '');
+                } elseif (trim($_POST['plex_token'] ?? '') !== '') {
+                    set_setting('plex_token', trim($_POST['plex_token'] ?? ''));
+                }
                 db_log_activity($current['id'], 'updated site settings');
                 $_SESSION['flash'] = ['type' => 'success', 'msg' => 'Settings saved.'];
             }
@@ -1472,6 +1481,26 @@ $act = ($tab === 'activity') ? admin_activity_snapshot($db) : null;
                        framing an arbitrary site is a real hazard and a direct video source is not.</p>
                 </div>
 
+                <div class="form-group">
+                    <label for="plex_url">Plex server URL</label>
+                    <input type="text" name="plex_url" id="plex_url"
+                           value="<?= htmlspecialchars(get_setting('plex_url', ''), ENT_QUOTES | ENT_SUBSTITUTE) ?>"
+                           placeholder="https://plex.example.com">
+                    <p class="hint">Base URL of your Plex Media Server, reachable over HTTPS. Lets a Timer BETA video
+                       cell play from your own library: paste a Plex link into the cell and the layout stores only the
+                       item reference.</p>
+                </div>
+                <div class="form-group">
+                    <label for="plex_token">Plex token</label>
+                    <input type="password" name="plex_token" id="plex_token" autocomplete="new-password"
+                           placeholder="<?= get_setting('plex_token', '') !== '' ? 'Saved. Leave blank to keep it.' : 'X-Plex-Token' ?>">
+                    <p class="hint">Opens your entire library, so it is never written into a layout and never sent to
+                       anyone but the layout's owner: a screen opened with the display QR code gets the cell with no
+                       video rather than the token. Leave blank to keep the stored value.<?php if (get_setting('plex_token', '') !== ''): ?>
+                       <label style="display:inline-flex;align-items:center;gap:.35rem;margin-top:.35rem">
+                           <input type="checkbox" name="plex_token_clear" value="1"> Remove the stored token
+                       </label><?php endif; ?></p>
+                </div>
 
                 <button type="submit" class="btn btn-primary" style="width:100%;margin-top:.25rem">
                     Save

--- a/www/db.php
+++ b/www/db.php
@@ -1946,6 +1946,153 @@ function stream_allowed_hosts(): array {
     return array_keys($out);
 }
 
+/* ── Plex Media Server ───────────────────────────────────────────────────────
+ * Backs the Timer BETA video cell's Plex source.
+ *
+ * A layout stores only a token-free reference ("plex:/library/metadata/12345").
+ * The server attaches the token at RENDER time and only for the layout's owner.
+ * That gate is not decoration: timer_beta.php admits anyone holding the
+ * display's remote_key, and that key is handed to the whole room as a QR code,
+ * so a token living in the layout would give every scanner the run of the
+ * library. The same reasoning is why the token is never a query parameter on
+ * our own API calls (see plex_api_get) — only on the media URL the browser
+ * must fetch directly, where there is no alternative.
+ */
+function plex_config(): array {
+    $raw = trim(get_setting('plex_url', ''));
+    $tok = trim(get_setting('plex_token', ''));
+    if ($raw === '' || $tok === '') return [];
+    $p = parse_url($raw);
+    if (!$p || !in_array(strtolower($p['scheme'] ?? ''), ['http', 'https'], true)) return [];
+    $host = strtolower($p['host'] ?? '');
+    if ($host === '') return [];
+    return [
+        'base'  => strtolower($p['scheme']) . '://' . $host . (isset($p['port']) ? ':' . (int)$p['port'] : ''),
+        'host'  => $host,
+        'token' => $tok,
+    ];
+}
+
+/**
+ * Canonicalize whatever the author pasted into "plex:/library/metadata/N".
+ *
+ * Accepts the app.plex.tv link the Plex web UI actually hands you (the target
+ * rides percent-encoded in the fragment), a direct URL on the configured
+ * server, or the canonical ref itself. Returns null for anything else — a URL
+ * on some other host must never be silently adopted as a Plex item.
+ */
+function plex_canonical_ref(string $raw): ?string {
+    $raw = trim($raw);
+    if ($raw === '' || strlen($raw) > 500) return null;
+    if (preg_match('#^plex:/library/metadata/(\d{1,12})$#', $raw, $m)) {
+        return 'plex:/library/metadata/' . $m[1];
+    }
+    $p = parse_url($raw);
+    if (!$p || empty($p['host'])) return null;
+    $h = preg_replace('/^www\./', '', strtolower($p['host']));
+    $cfg = plex_config();
+    if ($h !== 'app.plex.tv' && $h !== 'plex.tv' && !($cfg && $h === $cfg['host'])) return null;
+    // The metadata key is a query param on a direct URL and lives inside the
+    // fragment on app.plex.tv (…/#!/server/<id>/details?key=%2Flibrary%2F…).
+    $hay = ($p['path'] ?? '') . '?' . ($p['query'] ?? '') . '#' . ($p['fragment'] ?? '');
+    // Delimiter is ~ on purpose: the class below contains '#', which would end
+    // a #-delimited pattern early and make the rest read as modifiers.
+    if (preg_match('~key=([^&#]+)~', $hay, $m)) {
+        $key = urldecode($m[1]);
+        if (preg_match('#^/library/metadata/(\d{1,12})(?![0-9])#', $key, $k)) {
+            return 'plex:/library/metadata/' . $k[1];
+        }
+    }
+    if (preg_match('#/library/metadata/(\d{1,12})(?![0-9])#', $p['path'] ?? '', $m)) {
+        return 'plex:/library/metadata/' . $m[1];
+    }
+    return null;
+}
+
+/**
+ * GET a Plex API path as decoded JSON, or null on any failure.
+ * The token goes in a header, never the query string: query strings land in
+ * access logs and Referer headers, and this one opens the whole library.
+ */
+function plex_api_get(string $path, array $query = []): ?array {
+    $cfg = plex_config();
+    if (!$cfg) return null;
+    $url = $cfg['base'] . $path . ($query ? '?' . http_build_query($query) : '');
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => 8,
+        CURLOPT_CONNECTTIMEOUT => 4,
+        CURLOPT_FOLLOWLOCATION => false,
+        CURLOPT_HTTPHEADER     => ['Accept: application/json', 'X-Plex-Token: ' . $cfg['token']],
+    ]);
+    $body = curl_exec($ch);
+    $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($body === false || $code !== 200) return null;
+    $j = json_decode($body, true);
+    return is_array($j) ? $j : null;
+}
+
+/**
+ * Resolve a canonical ref to something a <video> element can actually play.
+ * Returns ['url' => …, 'title' => …, 'mode' => 'direct'|'transcode'] or null.
+ *
+ * Direct play when the browser can already decode the file as it sits. Anything
+ * else goes through Plex's transcoder as progressive MP4 (protocol=http) rather
+ * than HLS, because HLS needs hls.js in Chrome and Firefox and a third-party
+ * script has no room under script-src 'self'. Transcoding costs CPU on the
+ * Plex box for the length of the game.
+ */
+function plex_resolve(string $ref): ?array {
+    $cfg = plex_config();
+    if (!$cfg) return null;
+    if (!preg_match('#^plex:/library/metadata/(\d{1,12})$#', $ref, $m)) return null;
+    $id   = $m[1];
+    $meta = plex_api_get('/library/metadata/' . $id);
+    $item = $meta['MediaContainer']['Metadata'][0] ?? null;
+    if (!is_array($item)) return null;
+
+    $title = (string)($item['grandparentTitle'] ?? '') !== ''
+        ? $item['grandparentTitle'] . ' — ' . ($item['title'] ?? '')
+        : (string)($item['title'] ?? 'Untitled');
+
+    $media   = $item['Media'][0]   ?? null;
+    $part    = is_array($media) ? ($media['Part'][0] ?? null) : null;
+    $partKey = is_array($part) ? (string)($part['key'] ?? '') : '';
+
+    $container = strtolower((string)($media['container']  ?? ''));
+    $vcodec    = strtolower((string)($media['videoCodec'] ?? ''));
+    $acodec    = strtolower((string)($media['audioCodec'] ?? ''));
+    $direct = $partKey !== ''
+        && in_array($container, ['mp4', 'm4v'], true)
+        && in_array($vcodec, ['h264', 'avc1'], true)
+        && in_array($acodec, ['aac', 'mp3'], true);
+
+    if ($direct) {
+        return ['mode' => 'direct', 'title' => $title,
+                'url'  => $cfg['base'] . $partKey
+                        . (strpos($partKey, '?') === false ? '?' : '&')
+                        . 'X-Plex-Token=' . rawurlencode($cfg['token'])];
+    }
+    return ['mode' => 'transcode', 'title' => $title,
+            'url'  => $cfg['base'] . '/video/:/transcode/universal/start.mp4?' . http_build_query([
+                'path'                     => '/library/metadata/' . $id,
+                'mediaIndex'               => 0,
+                'partIndex'                => 0,
+                'protocol'                 => 'http',
+                'fastSeek'                 => 1,
+                'directPlay'               => 0,
+                'directStream'             => 1,
+                'videoQuality'             => 100,
+                'videoResolution'          => '1920x1080',
+                'maxVideoBitrate'          => 8000,
+                'audioBoost'               => 100,
+                'X-Plex-Client-Identifier' => 'gamenight-timer',
+                'X-Plex-Token'             => $cfg['token'],
+            ])];
+}
+
 /**
  * Emit SEO + social-share meta tags into a page <head>. Pages keep their own
  * <title>; this adds the description, canonical link, Open Graph, and Twitter

--- a/www/timer_beta.css
+++ b/www/timer_beta.css
@@ -194,7 +194,7 @@ body.tb-letterbox { background: #000; }
    weight ARE the video's size, same rule as every other cell. */
 .tb-cell-video .tb-cell-inner { width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; }
 .tb-video { width: 100%; height: 100%; border: 0; background: #000; }
-/* A <video> fills the same box as an embed iframe, but it has real
+/* A <video> (Plex) fills the same box as an embed iframe, but it has real
    intrinsic dimensions, so without this it stretches to the cell's aspect
    instead of letterboxing inside it. */
 video.tb-video { object-fit: contain; }

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -1349,6 +1349,19 @@ function safeImageSrc(v) {
          || /^\/img\/timer_beta\/[a-z0-9._-]{1,80}$/.test(v)) ? v : null;
 }
 
+// A media URL the SERVER resolved (Plex). There is no closed list to check it
+// against — the host comes from admin settings — so this enforces the scheme
+// only, which is what keeps a javascript: or data: source out of a <video>.
+// CSP media-src is the browser-enforced copy. The server never sends this key
+// to anyone but the layout's owner, so its presence is itself the permission.
+function safeMediaSrc(v) {
+    if (typeof v !== 'string' || !v) return null;
+    try {
+        var u = new URL(v, location.href);
+        return (u.protocol === 'https:' || u.protocol === 'http:') ? v : null;
+    } catch (e) { return null; }
+}
+
 // A direct media URL: HLS (.m3u8) or a plain file, from ANY https host. These
 // get a <video>, not an iframe — an iframe would download the file or show bare
 // browser chrome. No allowlist on purpose: a host picks the source for their own
@@ -1539,11 +1552,11 @@ function buildCell(spec) {
     // an unrecognised host draws the dashed placeholder instead of an embed
     // (CSP frame-src would refuse it anyway — belt and braces). The src is an
     // attribute assignment, never innerHTML.
-    if ('video' in spec) {
+    if ('video' in spec || 'videoMedia' in spec) {
         el.classList.add('tb-cell-video');
-        // A direct media URL (HLS or a file) becomes a real player; anything
-        // else is a provider embed and goes in an iframe below.
-        var mSrc = mediaStreamUrl(spec.video);
+        // A media URL the server resolved from a Plex ref. Only the layout's
+        // owner is sent one, so every other screen falls through to the stub.
+        var mSrc = safeMediaSrc(spec.videoMedia) || mediaStreamUrl(spec.video);
         var vSrc = mSrc ? '' : normalizeStreamUrl(spec.video);
         if (mSrc) {
             var vid = document.createElement('video');
@@ -1604,7 +1617,7 @@ function buildCell(spec) {
     if (spec.clockColors) clockCells.push(el);
 
     var rec = {
-        el: el, inner: inner, spec: spec, isImage: !!imgSrc || !!spec.qr || !!spec.chips || !!spec.seats || ('video' in spec),
+        el: el, inner: inner, spec: spec, isImage: !!imgSrc || !!spec.qr || !!spec.chips || !!spec.seats || ('video' in spec) || ('videoMedia' in spec),
         variants: Array.isArray(spec.variants) ? spec.variants : [],
         elSpans: [], lastText: null, lastVariant: -2, isFit: !!spec.fit
     };
@@ -2556,9 +2569,9 @@ if (window.TB_EMBED) {
         // renderer's own normalizer (same reason as validateCondition — the
         // tick the author sees and what the display loads can never disagree).
         normalizeStreamUrl: function (raw) { return normalizeStreamUrl(raw); },
-        // Exposed for the editor's paste check: without it the editor would
-        // judge direct media URLs by the embed rules and call a perfectly good
-        // .m3u8 unrecognised while the server accepted it.
+        // Exposed for the editor's paste check. Without it the editor would
+        // still be judging direct media URLs by the embed rules and calling a
+        // perfectly good .m3u8 unrecognised, while the server accepted it.
         mediaStreamUrl: function (raw) { return mediaStreamUrl(raw); },
         conditionNames: function () { return COND_NAMES.slice(); },
         // Trigger "Test" button: run an action list right now, ignoring

--- a/www/timer_beta_dl.php
+++ b/www/timer_beta_dl.php
@@ -36,15 +36,61 @@ $action = $_POST['action'] ?? $_GET['action'] ?? '';
  * layout that timer is currently showing — it cannot be pointed at any other
  * row, and it answers with the layout alone: no owner, no scope, no editable
  * flag, nothing that would let a viewer act on it. */
+/* Expand Plex refs into playable URLs on the way OUT to a browser.
+ *
+ * A layout stores "plex:/library/metadata/N" and nothing else. The playable
+ * URL is built here and added only when $allow says this caller owns the
+ * layout. Every other viewer — including a screen opened with the display's
+ * remote_key, which is handed to the whole room as a QR code — gets the ref
+ * without a URL, so the cell draws the empty-video stub rather than leaking a
+ * credential that opens the entire library.
+ *
+ * The ref itself STAYS in `video`. It carries nothing sensitive, and the
+ * layout editor reads and writes that key: dropping it here would round-trip
+ * the cell back through save as an ordinary empty video cell and quietly
+ * destroy the author's Plex reference. The resolved URL rides alongside in
+ * `videoMedia`, so the renderer can tell a media source from an iframe embed
+ * without sniffing. */
+function pk_plex_expand(array $node, bool $allow, array &$cache): array {
+    if (isset($node['cell']) && is_array($node['cell'])
+        && isset($node['cell']['video']) && is_string($node['cell']['video'])
+        && strncmp($node['cell']['video'], 'plex:', 5) === 0) {
+        $c = $node['cell'];
+        $ref = $c['video'];
+        if ($allow) {
+            if (!array_key_exists($ref, $cache)) {
+                $r = plex_resolve($ref);
+                $cache[$ref] = is_array($r) ? $r['url'] : null;
+            }
+            if ($cache[$ref] !== null) $c['videoMedia'] = $cache[$ref];
+        }
+        $node['cell'] = $c;
+    }
+    foreach ($node as $k => $v) {
+        if (is_array($v)) $node[$k] = pk_plex_expand($v, $allow, $cache);
+    }
+    return $node;
+}
+
 if ($action === 'get_layout' && ($rk = trim((string)($_GET['key'] ?? ''))) !== '') {
-    $q = $db->prepare('SELECT tl.id, tl.name, tl.layout
+    $q = $db->prepare('SELECT tl.id, tl.name, tl.layout, tl.created_by
                        FROM timer_state ts JOIN timer_layouts tl ON tl.id = ts.layout_id
                        WHERE ts.remote_key = ?');
     $q->execute([$rk]);
     $row = $q->fetch();
     if (!$row) { echo json_encode(['ok' => false, 'error' => 'Not found']); exit; }
+    $lay = json_decode($row['layout'], true);
+    $pxCache = [];
+    // Same Plex gate as the id path below, not a blanket refusal: the host's
+    // own display can carry a cast key too (castKeyParam appends it whenever
+    // the page was opened with one), and reaching this branch says nothing
+    // about who is asking. Admin AND owner still, so a scanned screen — which
+    // is the normal way a key holder gets here — gets no URL.
+    $pxAllow = $current && $current['role'] === 'admin'
+               && (int)$row['created_by'] === (int)$current['id'];
+    if (is_array($lay)) $lay = pk_plex_expand($lay, $pxAllow, $pxCache);
     echo json_encode(['ok' => true, 'id' => (int)$row['id'], 'name' => $row['name'],
-                      'layout' => json_decode($row['layout'], true)]);
+                      'layout' => $lay]);
     exit;
 }
 
@@ -106,6 +152,10 @@ function pk_lo_stream_url($v): ?string {
     if (!is_string($v)) return null;
     $v = trim($v);
     if ($v === '' || strlen($v) > 500) return null;
+    // A Plex item is stored as a token-free ref rather than a URL: the token is
+    // attached at render time, and only for the owner (see pk_plex_expand).
+    $px = plex_canonical_ref($v);
+    if ($px !== null) return $px;
     // A DIRECT media URL — .m3u8 from a restreamer, or a plain file — is
     // accepted from any https host, with no allowlist and no admin approval.
     // A host chooses the source for their own game; making that a support
@@ -622,6 +672,24 @@ function pk_lo_gc_images(PDO $db, array $candidateNames, int $exceptId): void {
 
 /* ── Actions ────────────────────────────────────────────────────────────── */
 
+// ─── GET: plex_check ───────────────────────────────────────
+// Editor-side probe for a pasted Plex link: confirms the item resolves and says
+// whether it will direct-play or transcode, so the author learns that at paste
+// time rather than when the room is watching. Returns the title and mode only,
+// never the URL — that carries the token.
+if ($action === 'plex_check') {
+    // Admin only, for the same reason the URL gate is: this probes the site's
+    // Plex library with the site's token, and a member has no claim on either.
+    if (!$isAdmin) { http_response_code(403); echo json_encode(['ok' => false, 'error' => 'Admins only.']); exit; }
+    $ref = plex_canonical_ref((string)($_GET['url'] ?? ''));
+    if ($ref === null) { echo json_encode(['ok' => false, 'error' => 'That is not a Plex link.']); exit; }
+    if (!plex_config()) { echo json_encode(['ok' => false, 'error' => 'No Plex server is configured in Settings.']); exit; }
+    $r = plex_resolve($ref);
+    if (!$r) { echo json_encode(['ok' => false, 'error' => 'Plex did not recognise that item.']); exit; }
+    echo json_encode(['ok' => true, 'ref' => $ref, 'title' => $r['title'], 'mode' => $r['mode']]);
+    exit;
+}
+
 if ($action === 'get_layouts') {
     $stmt = $db->prepare(
         'SELECT tl.id, tl.name, tl.is_global, tl.created_by, tl.league_id, l.name AS league_name
@@ -637,6 +705,7 @@ if ($action === 'get_layouts') {
 }
 
 if ($action === 'get_layout') {
+    $pxCache = [];
     $id = (int)($_GET['id'] ?? 0);
     $stmt = $db->prepare(
         'SELECT * FROM timer_layouts WHERE id = ? AND (is_global = 1 OR created_by = ?
@@ -647,7 +716,13 @@ if ($action === 'get_layout') {
     echo json_encode(['ok' => true, 'id' => (int)$row['id'], 'name' => $row['name'],
         'is_global' => (int)$row['is_global'], 'league_id' => $row['league_id'] ? (int)$row['league_id'] : null,
         'created_by' => (int)$row['created_by'],
-        'layout' => json_decode($row['layout'], true),
+        // Plex URLs carry a token that opens the WHOLE library, and that
+        // credential belongs to the site, not to whoever happens to own a
+        // layout — owning one is self-serve, so gating on ownership alone
+        // would let any member mint a token-bearing URL by pasting a Plex
+        // link into a layout of their own. Admin AND owner, or no URL.
+        'layout' => pk_plex_expand(json_decode($row['layout'], true) ?: [],
+                                    $isAdmin && (int)$row['created_by'] === $uid, $pxCache),
         'editable' => pk_lo_may_modify($db, $row, $uid, $isAdmin)]);
     exit;
 }

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -1598,15 +1598,15 @@ function renderInspector() {
             vWrap.className = 'tbe-field';
             var vl = document.createElement('span'); vl.textContent = 'Video stream'; vWrap.appendChild(vl);
             var vn = document.createElement('div'); vn.className = 'tbe-note';
-            vn.textContent = 'Paste a YouTube, Twitch, Vimeo or Kick link, or any direct https '
-                           + '.m3u8 / .mp4 URL — that is how a restream (IPTV, a live game) gets here. '
+            vn.textContent = 'Paste a YouTube, Twitch, Vimeo or Kick link, a Plex link, or any direct '
+                           + 'https .m3u8 / .mp4 URL — that is how a restream (IPTV, a live game) gets here. '
                            + 'A direct video URL needs no approval from an admin, and everyone watching the '
                            + 'display sees it. The video fills this cell — give the box more weight for a '
                            + 'bigger picture. Streams mute themselves while alarm sounds play.';
             vWrap.appendChild(vn);
             insp.appendChild(vWrap);
             var vu = document.createElement('input');
-            vu.type = 'text'; vu.placeholder = 'https://…  (YouTube link, or a .m3u8 restream)';
+            vu.type = 'text'; vu.placeholder = 'https://…  (YouTube, Plex, or a .m3u8 restream)';
             vu.value = cell.video || '';
             var vErr = document.createElement('div'); vErr.className = 'tbe-note';
             var localOk = function (raw) {
@@ -1643,16 +1643,56 @@ function renderInspector() {
                 }
                 return 'That host did not work out. Check the link opens on its own in a browser tab.';
             };
+            // A stored Plex cell holds the canonical ref, never a URL — the
+            // token is attached server-side at display time, for an admin
+            // viewing their own layout and nobody else.
+            var isPlexRef = function (raw) { return /^plex:\/library\/metadata\/\d+$/.test(raw); };
             var vCheck = function (msg) {
                 var raw = vu.value.trim();
                 if (msg !== undefined) { vu.style.borderColor = ''; vErr.textContent = msg; return; }
+                if (isPlexRef(raw)) {
+                    vu.style.borderColor = '';
+                    vErr.textContent = 'Plex item. It plays on your own display only — a screen opened with '
+                                     + 'the QR code shows a placeholder. The preview above stays a placeholder '
+                                     + 'until you save and reload.';
+                    return;
+                }
                 vu.style.borderColor = (raw === '' || localOk(raw)) ? '' : '#ef4444';
                 vErr.textContent = raw === '' ? 'No link yet — the cell shows a placeholder until one is pasted.'
                                  : localOk(raw) ? '' : diagnose(raw);
             };
             vu.addEventListener('input', vCheck);
             vu.addEventListener('change', function () {
-                pushUndo(); cell.video = vu.value.trim(); refresh(true); vCheck();
+                var raw = vu.value.trim();
+                if (raw === '' || localOk(raw) || isPlexRef(raw)) {
+                    pushUndo(); cell.video = raw; refresh(true); vCheck();
+                    return;
+                }
+                // Not a host the renderer knows. It may still be a Plex link,
+                // and only the server can tell — it holds the token and does
+                // the library lookup. Ask before calling it invalid.
+                vCheck('Checking…');
+                fetch('/timer_beta_dl.php?action=plex_check&url=' + encodeURIComponent(raw),
+                      { credentials: 'same-origin' })
+                    .then(function (r) { return r.json(); })
+                    .then(function (d) {
+                        pushUndo();
+                        if (d && d.ok) {
+                            cell.video = d.ref;
+                            vu.value = d.ref;
+                            refresh(true);
+                            vCheck('Plex: ' + d.title
+                                 + (d.mode === 'transcode' ? ' — Plex will transcode this while it plays.'
+                                                           : ' — plays directly, no transcode.')
+                                 + ' Your display only; a QR-opened screen shows a placeholder.');
+                        } else {
+                            cell.video = raw; refresh(true);
+                            vu.style.borderColor = '#ef4444';
+                            vErr.textContent = (d && d.error && d.error !== 'That is not a Plex link.')
+                                ? d.error : diagnose(raw);
+                        }
+                    })
+                    .catch(function () { pushUndo(); cell.video = raw; refresh(true); vCheck(); });
             });
             vCheck();
             insp.appendChild(field('Stream URL', vu));
@@ -1691,7 +1731,7 @@ function renderInspector() {
 
         var toVid = document.createElement('button');
         toVid.className = 'tbe-mini'; toVid.textContent = 'Use a video stream instead';
-        toVid.title = 'Embed a YouTube / Twitch / Vimeo / Kick video, or play a direct stream, in this cell';
+        toVid.title = 'Embed a YouTube / Twitch / Vimeo / Kick video, or play from Plex, in this cell';
         toVid.addEventListener('click', function () { pushUndo(); cell.video = ''; refresh(true); renderInspector(); });
         insp.appendChild(toVid);
 


### PR DESCRIPTION
Held back from v0.2113 so the HLS half could land first. Rebuilt on top of it, so this branch carries only the Plex code; the `<video>` element and hls.js it depends on are already in main.

**Do not merge yet.** `plex_resolve()` has only been exercised against a stub API, and no browser has played a Plex cell. It needs a real token in Settings and a real library item first.

## How it works

A layout stores a token-free ref, `plex:/library/metadata/12345`. Nothing sensitive lands in the layout, so exporting or sharing one leaks nothing. The playable URL is built server-side and attached at render time.

Direct play when the file is already browser-friendly (MP4/H.264/AAC); otherwise Plex's transcoder as progressive MP4 via `protocol=http`, deliberately not HLS, so no additional player work is needed beyond what v0.2113 already ships.

## The gate, and why it is what it is

Admin **and** owner of the layout. Not a policy preference: `X-Plex-Token` opens the entire library and never expires on its own, and `timer_beta.php` admits anyone holding the display's `remote_key`, which is handed to the whole room as a QR code.

Ownership alone would not be enough, because owning a layout is self-serve. Any member could create one with a Plex cell, become its owner, and mint a token-bearing URL. Hence admin as well.

Applied identically on both layout read paths, including the key path, since the host's own display can carry a cast key too.

## Verified with a stub API

| Case | Result |
|---|---|
| QR key path, not logged in | ref only, no URL |
| Non-admin owner | ref only, no URL |
| Admin + owner | full URL with token |
| Admin + owner, display carrying a cast key | full URL with token |
| MP4/H.264/AAC | direct play |
| MKV/HEVC/AC3 | transcode |

Link parsing passes 11 cases including `app.plex.tv`, direct URLs and `/children` suffixes, and rejects other hosts and traversal attempts.

Two bugs fixed during that testing: a `#` delimiter collision that broke the regex on exactly the URL the Plex web app gives you, and a silent truncation that turned an over-long rating key into a different item's id.

## Known limitation

This makes Plex an admin-only feature, which cuts against the project's model of leagues as the host tier. The cause is the credential, not policy: as long as the token must reach the browser, it cannot safely be handed to a league owner. Proxying the bytes through GameNight would move it to ordinary league-role policy, at the cost of VPS bandwidth and a long-lived worker per stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)