### PR TITLE
Video cell survives screen rebuilds, and starts with sound (v0.2114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2114] - 2026-08-26
+
+### Fixed
+
+- **A video cell no longer restarts, and no longer loses its sound, every time
+  the display changes screens.** `buildScreen()` wipes the tree and rebuilds it
+  on every screen change (cycling, a break screen, a trigger takeover), which
+  meant a brand new `<video>`, a brand new hls.js and a brand new manifest fetch
+  each time. On a cycling layout that reads as the stream reloading itself every
+  few minutes, and any unmute the host had done went with the discarded element.
+  Media elements are now cached by source and re-parented into the rebuilt tree
+  rather than recreated; `sweepVideoCache()` runs after the tree exists and
+  disposes only the players the new screen genuinely dropped, resuming any that
+  were paused by being detached.
+
+- **A stream starts with sound.** The `<video>` was hard-coded `muted` on the
+  theory that autoplay demands it. Autoplay with sound is in fact granted once
+  the page has user activation, which a display that has been clicked always
+  has, so `tbTryPlay()` now asks for sound first and falls back to muted only if
+  the browser actually refuses. The host's choice is remembered per device in
+  `gn.tbStreamMuted`, mirroring the existing `gn.muteStreamDuringAlarms`
+  convention, so it survives both a screen rebuild and a page reload.
+
+- **The level alarm no longer trains the display to stay silent.**
+  `tbMuteStreamForAlarm()` set `STREAM_MUTED_BY_ALARM` *after* calling
+  `tbStreamMute(true)`. Muting a real media element fires `volumechange`, so the
+  new preference listener saw the flag still clear and recorded the alarm's own
+  ducking as "the host wants this muted" — one level change and every later load
+  would have started silent. The flag is now set before the call.
+
+  Verified in a browser this time, not just structurally:
+  `qa-headless/hls_persist_check.js` drives Chromium against a live HLS stream
+  and asserts the stream actually plays, that the same element survives two
+  rebuilds, that playback and unmute survive with it, and that a stored unmute
+  is honoured on reload. Confirmed to fail on v0.2113 with exactly the three
+  symptoms above before passing on this build.
+
+---
+
 ## [v0.2113] - 2026-08-26
 
 ### Added

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -738,11 +738,15 @@ function tbMuteStreamForAlarm(durationMs) {
     try {
         if (localStorage.getItem('gn.muteStreamDuringAlarms') === 'false') return;
     } catch (e) {}
-    tbStreamMute(true);
+    // Flag BEFORE muting, not after: muting a <video> fires volumechange, and
+    // the preference listener must be able to tell the alarm's ducking from the
+    // host reaching for the volume. Set afterwards, one alarm would be recorded
+    // as "the host wants this muted" and every later load would start silent.
     STREAM_MUTED_BY_ALARM = true;
+    tbStreamMute(true);
     if (STREAM_UNMUTE_TIMER) clearTimeout(STREAM_UNMUTE_TIMER);
     STREAM_UNMUTE_TIMER = setTimeout(function () {
-        if (STREAM_MUTED_BY_ALARM) { tbStreamMute(false); STREAM_MUTED_BY_ALARM = false; }
+        if (STREAM_MUTED_BY_ALARM) { tbStreamMute(false); STREAM_MUTED_BY_ALARM = false; }   // flag held across the call, cleared after
         STREAM_UNMUTE_TIMER = null;
     }, durationMs);
 }
@@ -1366,7 +1370,6 @@ function mediaStreamUrl(raw) {
     return u.toString();
 }
 
-var hlsPlayers = []; // live hls.js instances — destroyed on every re-render
 
 // Point a <video> at a source, bringing hls.js in for .m3u8 where the browser
 // has no native HLS. Safari (and iOS in general) plays HLS directly, so it
@@ -1393,7 +1396,59 @@ function attachHls(vid, src) {
     });
     h.loadSource(src);
     h.attachMedia(vid);
-    hlsPlayers.push(h);
+    return h;
+}
+
+/* A <video> must SURVIVE buildScreen().
+ *
+ * buildScreen() wipes the tree and rebuilds it on every screen change: cycling,
+ * a break screen, a trigger takeover. Rebuilding a video cell from scratch each
+ * time meant a fresh element, a fresh hls.js, a fresh manifest fetch — the
+ * stream visibly restarted every few minutes and any unmute the host had done
+ * was lost with the old element. So elements are cached by source and re-parented
+ * into the new tree instead of recreated, and the sweep below disposes only the
+ * ones the new screen genuinely dropped. */
+var videoCache = {};
+
+// The host's sound choice, remembered per device. Mirrors the classic timer's
+// gn.muteStreamDuringAlarms convention. Default UNMUTED: a stream nobody can
+// hear is not what anyone put on the display for.
+function tbStreamMutePref() {
+    try { return localStorage.getItem('gn.tbStreamMuted') === 'true'; } catch (e) { return false; }
+}
+function tbSetStreamMutePref(m) {
+    try { localStorage.setItem('gn.tbStreamMuted', m ? 'true' : 'false'); } catch (e) {}
+}
+
+// Autoplay WITH sound needs user activation, and a display that has been
+// clicked (Start) usually has it. Ask for sound first and fall back to muted
+// only if the browser actually refuses, rather than assuming it will.
+function tbTryPlay(vid) {
+    var p;
+    try { p = vid.play(); } catch (e) { return; }
+    if (p && p.catch) {
+        p.catch(function () {
+            if (!vid.muted) {
+                vid.muted = true;
+                var q; try { q = vid.play(); } catch (e) { return; }
+                if (q && q.catch) q.catch(function () {});
+            }
+        });
+    }
+}
+
+// Dispose cached players the rebuilt tree no longer contains. Anything still
+// connected is on screen and must keep playing untouched.
+function sweepVideoCache() {
+    Object.keys(videoCache).forEach(function (k) {
+        var rec = videoCache[k];
+        if (rec.el && rec.el.isConnected) {
+            if (rec.el.paused) tbTryPlay(rec.el);
+            return;
+        }
+        if (rec.hls) { try { rec.hls.destroy(); } catch (e) {} }
+        delete videoCache[k];
+    });
 }
 
 // Normalize a user-pasted streaming URL into a safe embed URL — the classic
@@ -1546,17 +1601,28 @@ function buildCell(spec) {
         var mSrc = mediaStreamUrl(spec.video);
         var vSrc = mSrc ? '' : normalizeStreamUrl(spec.video);
         if (mSrc) {
-            var vid = document.createElement('video');
-            vid.className = 'tb-video';
-            attachHls(vid, mSrc);
-            vid.autoplay = true;
-            // Autoplay is only granted to a muted element, and the level alarm
-            // needs the audio channel regardless. `controls` is how the host
-            // unmutes it on the TV; the iframe path gets that from the
-            // provider's own player.
-            vid.muted = true;
-            vid.controls = true;
-            vid.setAttribute('playsinline', '');
+            var rec = videoCache[mSrc], vid;
+            if (rec && rec.el) {
+                // Already playing from an earlier screen: re-parent it, do not
+                // rebuild it. Moving the node keeps the buffer and the sound.
+                vid = rec.el;
+            } else {
+                vid = document.createElement('video');
+                vid.className = 'tb-video';
+                vid.autoplay = true;
+                // `controls` is how the host changes sound on the TV; the iframe
+                // path gets that from the provider's own player.
+                vid.controls = true;
+                vid.muted = tbStreamMutePref();
+                vid.setAttribute('playsinline', '');
+                rec = videoCache[mSrc] = { el: vid, hls: attachHls(vid, mSrc) };
+                // Remember what the host chose, so it survives the next rebuild
+                // AND the next page load. Ignored while the alarm holds the
+                // channel, or ducking would be recorded as an intentional mute.
+                vid.addEventListener('volumechange', function () {
+                    if (!STREAM_MUTED_BY_ALARM) tbSetStreamMutePref(vid.muted);
+                });
+            }
             if (window.TB_EMBED) vid.style.pointerEvents = 'none';
             inner.appendChild(vid);
             videoFrames.push(vid);
@@ -1709,8 +1775,6 @@ function buildScreen(idx) {
         ? CURRENT_LAYOUT.styles : {};
     rebuildElementIndex();
     var screen = CURRENT_LAYOUT.screens[idx] || { root: { col: [] } };
-    hlsPlayers.forEach(function (h) { try { h.destroy(); } catch (e) {} });
-    hlsPlayers = [];
     fitCells = []; clockCells = []; allCells = []; whenBoxes = []; qrCells = []; chipCells = []; seatCells = []; videoFrames = [];
     root.textContent = '';
     root.style.background = '';
@@ -1740,6 +1804,9 @@ function buildScreen(idx) {
     drawQrCells();
     drawChipCells();
     drawSeatCells();
+    // After the tree exists: dispose players this screen dropped, and resume
+    // any that were paused by being detached during the rebuild.
+    sweepVideoCache();
 }
 
 function renderLayoutObj(layout) {

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2113');
+define('APP_VERSION', '0.2114');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Two bugs reported from live testing of v0.2113 against a Red Bull TV HLS stream: the stream started muted, and every few minutes it appeared to reload itself with the sound muted again. They turned out to share a root cause, plus a third bug found while fixing them.

## The stream restarted every few minutes

`buildScreen()` wipes the tree and rebuilds it on every screen change: cycling, a break screen, a trigger takeover. A video cell was rebuilt from scratch each time, meaning a new `<video>`, a new hls.js instance and a new manifest fetch. On a cycling layout that reads exactly as the reporter described, a page refresh every few minutes, and any unmute went with the discarded element.

Media elements are now cached by source and re-parented into the rebuilt tree rather than recreated. `sweepVideoCache()` runs after the tree exists and disposes only the players the new screen genuinely dropped, resuming any paused by being detached.

## It started muted

The element was hard-coded `muted` on the theory that autoplay requires it. Autoplay with sound is actually granted once the page has user activation, which a display someone has clicked always has. `tbTryPlay()` now asks for sound first and falls back to muted only if the browser refuses. The host's choice is remembered per device in `gn.tbStreamMuted`, mirroring the existing `gn.muteStreamDuringAlarms` convention, so it survives a rebuild and a reload.

## The alarm was training it to stay silent

Found while fixing the above. `tbMuteStreamForAlarm()` set `STREAM_MUTED_BY_ALARM` *after* calling `tbStreamMute(true)`. Muting a real media element fires `volumechange`, so the new preference listener saw the flag still clear and would have recorded the alarm's own ducking as an intentional mute. One level change and every later load starts silent. Flag is now set before the call.

## Verified in a browser

v0.2113 shipped with structural tests only. This one did not. `qa-headless/hls_persist_check.js` drives Chromium against a live HLS stream:

```
PASS  hls.js loaded from vendor/
PASS  a real <video> rendered (not an iframe)
PASS  stream is genuinely PLAYING (currentTime advanced)
PASS  element can be unmuted
PASS  SAME element survived two rebuilds (not recreated)
PASS  no duplicate players left behind (got 1)
PASS  still playing after the rebuild
PASS  unmute survived the rebuild
PASS  playback continued rather than restarting (2.3 -> 4.9)
PASS  stored mute preference honoured on reload
PASS  stored UNMUTE preference honoured on reload (starts with sound)
```

Run against v0.2113 first, it fails on exactly the three reported symptoms (element recreated, unmute lost, always starts muted), so it is a real regression guard rather than a test that agrees with whatever it is given.

The check lives in `qa-headless/`, outside the repo, alongside the existing `video_cell_check.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)