### PR TITLE
Duck stream audio with a ramp instead of cutting it (v0.2115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2115] - 2026-08-26
+
+### Changed
+
+- **The level alarm now ducks a stream's audio instead of cutting it.** Muting a
+  live stream dead for five seconds and snapping it back is more jarring than
+  the alarm it is making room for. `tbFadeVolume()` ramps the volume with a
+  raised-cosine ease, 250ms out and 600ms back in: out quickly enough to clear
+  the way, back slowly enough not to startle a room. The asymmetry is
+  deliberate, since a duck that returns as abruptly as it left draws more
+  attention than the duck. An in-flight ramp is cancelled before a new one
+  starts, so overlapping alarms cannot leave two animation loops fighting over
+  one volume.
+
+  Both the mute state and the *level* are captured before ducking. A host who
+  muted the stream deliberately is never unmuted by the fade back in, and a host
+  who turned it down to sit under table talk returns to that level rather than
+  to full volume. Provider embeds (YouTube, Vimeo) keep the old hard duck: their
+  volume cannot be read back over `postMessage`, so ramping blind could hand the
+  room a louder stream than the host chose.
+
+- **A stream's volume is remembered, not just whether it was muted.**
+  `gn.tbStreamVolume` joins `gn.tbStreamMuted`, so a level set on a device
+  survives a screen rebuild and a page reload.
+
+### Fixed
+
+- **The alarm's own fade can no longer be mistaken for the host adjusting the
+  volume.** `STREAM_MUTED_BY_ALARM` was cleared as soon as `tbStreamMute(false)`
+  returned, but the fade back in runs for another 600ms after that, and every
+  step of it fires `volumechange`. The preference listener would have stored a
+  half-faded level as the host's setting, so the stream came back quieter after
+  every alarm until it was effectively silent. The flag is now held until the
+  ramp actually finishes.
+
+  Covered by `qa-headless/hls_fade_check.js`, which drives Chromium against a
+  live HLS stream through the real trigger path and asserts the volume passes
+  through intermediate values in both directions, returns to the host's 0.4
+  rather than to 1.0, leaves the stored preference untouched, and never unmutes
+  a stream the host had deliberately muted.
+
+---
+
 ## [v0.2114] - 2026-08-26
 
 ### Fixed

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -701,24 +701,68 @@ var deviceOverride = null;
  * the classic timer carries over here. */
 var STREAM_MUTED_BY_ALARM = false;
 var STREAM_UNMUTE_TIMER = null;
+// Fade timings. Out fast enough to clear the way for the alarm, back in slow
+// enough not to startle a room. Deliberately asymmetric: a duck that returns as
+// abruptly as it left is more noticeable than the duck itself.
+var STREAM_FADE_OUT_MS = 250;
+var STREAM_FADE_IN_MS  = 600;
+
+/* Ramp a media element's volume instead of cutting it.
+ *
+ * Eased with a raised cosine so both ends are smooth; a linear ramp over this
+ * distance has an audible corner where it starts and stops. Any ramp already
+ * running on the element is cancelled first, so overlapping alarms cannot leave
+ * two rAF loops fighting over one volume. */
+function tbFadeVolume(vid, to, ms, done) {
+    if (vid._fadeRaf) { cancelAnimationFrame(vid._fadeRaf); vid._fadeRaf = null; }
+    var from = vid.volume;
+    to = Math.max(0, Math.min(1, to));
+    if (ms <= 0 || Math.abs(from - to) < 0.005) {
+        try { vid.volume = to; } catch (e) {}
+        if (done) done();
+        return;
+    }
+    var t0 = performance.now();
+    vid._fadeRaf = requestAnimationFrame(function step(now) {
+        var k = Math.min(1, (now - t0) / ms);
+        var e = 0.5 - Math.cos(Math.PI * k) / 2;
+        try { vid.volume = Math.max(0, Math.min(1, from + (to - from) * e)); } catch (err) {}
+        if (k < 1) { vid._fadeRaf = requestAnimationFrame(step); }
+        else { vid._fadeRaf = null; if (done) done(); }
+    });
+}
+
 function tbStreamMute(on) {
     videoFrames.forEach(function (frame) {
         if (!frame.isConnected || !frame.src) return;
         if (frame.tagName === 'VIDEO') {
-            // A real media element: mute it directly, no postMessage involved.
-            // Remember what it was first, so the alarm's unmute can never
-            // switch on audio the host had deliberately muted.
+            // A real media element: ramp it rather than cut it. Both the mute
+            // state AND the level are remembered, because a host who muted
+            // deliberately must not be unmuted by the fade back in, and one who
+            // set a quiet level must return to THAT, never to full volume.
             if (on) {
                 if (frame.dataset.preAlarmMuted === undefined) {
                     frame.dataset.preAlarmMuted = frame.muted ? '1' : '0';
+                    frame.dataset.preAlarmVol   = String(frame.volume);
                 }
-                frame.muted = true;
+                if (frame.muted) return;             // nothing audible to duck
+                tbFadeVolume(frame, 0, STREAM_FADE_OUT_MS, function () { frame.muted = true; });
             } else {
-                if (frame.dataset.preAlarmMuted === '0') frame.muted = false;
+                var wasMuted = frame.dataset.preAlarmMuted === '1';
+                var vol = parseFloat(frame.dataset.preAlarmVol);
+                if (isNaN(vol)) vol = 1;
                 delete frame.dataset.preAlarmMuted;
+                delete frame.dataset.preAlarmVol;
+                if (wasMuted) return;                // host had it off; leave it
+                frame.muted = false;
+                try { frame.volume = 0; } catch (e) {}
+                tbFadeVolume(frame, vol, STREAM_FADE_IN_MS);
             }
             return;
         }
+        // Provider embeds only expose mute/unMute over postMessage and their
+        // current level cannot be read back, so ramping blind could hand the
+        // room a louder stream than the host set. They stay a hard duck.
         try {
             var host = new URL(frame.src).hostname;
             if (/youtube/.test(host)) {
@@ -746,7 +790,15 @@ function tbMuteStreamForAlarm(durationMs) {
     tbStreamMute(true);
     if (STREAM_UNMUTE_TIMER) clearTimeout(STREAM_UNMUTE_TIMER);
     STREAM_UNMUTE_TIMER = setTimeout(function () {
-        if (STREAM_MUTED_BY_ALARM) { tbStreamMute(false); STREAM_MUTED_BY_ALARM = false; }   // flag held across the call, cleared after
+        if (STREAM_MUTED_BY_ALARM) {
+            tbStreamMute(false);
+            // Hold the flag until the ramp FINISHES, not merely until the call
+            // returns. Every step of the fade fires volumechange, and the
+            // preference listener must not read the ramp as the host reaching
+            // for the volume; it would store a half-faded level as their
+            // setting and the stream would come back quieter after every alarm.
+            setTimeout(function () { STREAM_MUTED_BY_ALARM = false; }, STREAM_FADE_IN_MS + 80);
+        }
         STREAM_UNMUTE_TIMER = null;
     }, durationMs);
 }
@@ -1419,6 +1471,17 @@ function tbStreamMutePref() {
 function tbSetStreamMutePref(m) {
     try { localStorage.setItem('gn.tbStreamMuted', m ? 'true' : 'false'); } catch (e) {}
 }
+// The level as well as the switch. Now that the alarm ramps rather than mutes,
+// a host who turned the stream down to sit under table talk should find it
+// there next time instead of back at full.
+function tbStreamVolPref() {
+    var v;
+    try { v = parseFloat(localStorage.getItem('gn.tbStreamVolume')); } catch (e) { v = NaN; }
+    return (isNaN(v) || v < 0 || v > 1) ? 1 : v;
+}
+function tbSetStreamVolPref(v) {
+    try { localStorage.setItem('gn.tbStreamVolume', String(Math.max(0, Math.min(1, v)))); } catch (e) {}
+}
 
 // Autoplay WITH sound needs user activation, and a display that has been
 // clicked (Start) usually has it. Ask for sound first and fall back to muted
@@ -1614,13 +1677,16 @@ function buildCell(spec) {
                 // path gets that from the provider's own player.
                 vid.controls = true;
                 vid.muted = tbStreamMutePref();
+                try { vid.volume = tbStreamVolPref(); } catch (e) {}
                 vid.setAttribute('playsinline', '');
                 rec = videoCache[mSrc] = { el: vid, hls: attachHls(vid, mSrc) };
                 // Remember what the host chose, so it survives the next rebuild
                 // AND the next page load. Ignored while the alarm holds the
                 // channel, or ducking would be recorded as an intentional mute.
                 vid.addEventListener('volumechange', function () {
-                    if (!STREAM_MUTED_BY_ALARM) tbSetStreamMutePref(vid.muted);
+                    if (STREAM_MUTED_BY_ALARM) return;   // the alarm's ramp, not the host
+                    tbSetStreamMutePref(vid.muted);
+                    tbSetStreamVolPref(vid.volume);
                 });
             }
             if (window.TB_EMBED) vid.style.pointerEvents = 'none';

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2114');
+define('APP_VERSION', '0.2115');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
The level alarm muted a live stream dead for five seconds and snapped it back. That is more jarring than the alarm it is making room for, so it now fades.

## The ramp

`tbFadeVolume()` eases the volume with a raised cosine, **250ms out and 600ms back in**. Out quickly enough to clear the way for the alarm, back slowly enough not to startle a room. The asymmetry is deliberate: a duck that returns as abruptly as it left draws more attention than the duck does.

An in-flight ramp is cancelled before a new one starts, so overlapping alarms cannot leave two `requestAnimationFrame` loops fighting over one volume.

## What it remembers

Both the mute state **and the level** are captured before ducking:

- A host who muted the stream deliberately is never unmuted by the fade back in.
- A host who turned it down to sit under table talk returns to *that* level, not to full volume.

`gn.tbStreamVolume` joins `gn.tbStreamMuted`, so a level set on a device survives a screen rebuild and a reload.

Provider embeds (YouTube, Vimeo) keep the old hard duck deliberately. Their volume cannot be read back over `postMessage`, so ramping blind could hand the room a louder stream than the host chose.

## A bug the ramp exposed

`STREAM_MUTED_BY_ALARM` was cleared as soon as `tbStreamMute(false)` returned, but the fade back in runs for another 600ms after that, and every step fires `volumechange`. The preference listener would have stored a half-faded level as the host's setting, so the stream came back quieter after every alarm until it was effectively silent. The flag is now held until the ramp actually finishes.

## Verified in a browser

`qa-headless/hls_fade_check.js` drives Chromium against a live HLS stream through the real trigger path (`runActions` -> `tbPlaySound` -> `tbMuteStreamForAlarm`), sampling volume every 25ms:

```
PASS  host volume 0.4 remembered
PASS  volume RAMPED down through intermediate values (6 samples between)
PASS  reached silence (0.000)
PASS  returned to the host level 0.4, not full (0.400)
PASS  unmuted after the alarm
PASS  the RAMP did not overwrite the stored preference (0.4)
PASS  ramp had intermediate steps in both directions (18)
PASS  a deliberately muted stream is NOT unmuted by the alarm
```

`hls_persist_check.js` re-run clean, so v0.2114's element caching is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)