### PR TITLE
Allow blob workers in CSP so HLS plays in Firefox (v0.2116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2116] - 2026-08-27
+
+### Fixed
+
+- **HLS video played in Chrome and Edge but showed nothing in Firefox.**
+  `worker-src` was `'self'`, and hls.js runs its demuxer in a Worker created
+  from a `blob:` URL. Chromium tolerates that; Firefox enforces the directive
+  and refuses the worker outright, so hls.js never demuxed a byte and the cell
+  sat at `readyState 0` with no error on the element, the only clue being a CSP
+  violation in the console. The directive is now `'self' blob:`, which concedes
+  little: `script-src` carries a nonce, so an attacker cannot run the script
+  that would be needed to construct a blob worker in the first place.
+
+  Confirmed by driving both engines against the same page and stream:
+  Firefox paused at `readyState 0` with the violation logged, Chromium playing
+  at `currentTime 8.86` with `readyState 4` and a clean console.
+
+---
+
 ## [v0.2115] - 2026-08-26
 
 ### Changed

--- a/www/auth.php
+++ b/www/auth.php
@@ -63,7 +63,14 @@ $_csp = implode('; ', [
     "object-src 'none'",
     // Service worker for Web Push (sw.js). Workers don't fall back to
     // script-src in all browsers, so declare explicitly.
-    "worker-src 'self'",
+    //
+    // `blob:` is required by hls.js, which runs its demuxer in a Worker created
+    // from a blob URL. Without it Firefox refuses the worker outright and video
+    // never decodes, while Chromium allows it — so the timer played in Edge and
+    // showed nothing in Firefox, with the only clue a CSP violation in the
+    // console. It concedes little: script-src carries a nonce, so an attacker
+    // cannot run the script that would be needed to construct a blob worker.
+    "worker-src 'self' blob:",
     "base-uri 'self'",
     "form-action 'self'",
     "frame-ancestors 'none'",

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2115');
+define('APP_VERSION', '0.2116');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
A stream that played fine in Edge showed nothing in Firefox. The cause was ours, not the stream's.

## What happened

`worker-src` was `'self'`. hls.js runs its demuxer in a **Worker created from a `blob:` URL**, which that directive does not permit. Chromium tolerates it; Firefox enforces the spec and refuses the worker outright.

The failure mode is nasty because nothing looks broken: the `<video>` element reports no error, `video.error` is null, and it simply sits at `readyState 0` forever. The only evidence is a CSP violation in the console, which nobody checks when the obvious conclusion is "the stream is bad."

Now `'self' blob:`. That concedes little: `script-src` carries a per-request nonce, so an attacker cannot execute the script that would be needed to construct a blob worker in the first place.

## Verified across both engines

Same page, same stream, same moment:

| | Firefox (before) | Chromium |
|---|---|---|
| paused | **true** | false |
| currentTime | **0** | 8.86 |
| readyState | **0** | 4 |
| console | **worker-src violation** | clean |

After the change the violation is gone.

Full end-to-end confirmation in Firefox needs a browser with H.264, which Playwright's Firefox build does not ship (`canPlayType('video/mp4; codecs="avc1.4d0028"')` returns empty there, while Chromium returns `probably`). The CSP behaviour is engine-level and independent of codec support, so it is verified; final playback confirmation is on a real Firefox.

## Related, but outside this repo

The same investigation turned up a second, unrelated cause of Firefox failures: many IPTV channels carry **AC-3 audio**, which Firefox has never supported (a licensed codec Chrome and Edge get from the OS). That is fixed on the streaming host by re-encoding audio to AAC while still copying video, costing about 8% of a core. Nothing in GameNight needed to change for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)