### PR TITLE
Stream no longer starts muted every time (v0.2117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2117] - 2026-08-27
+
+### Fixed
+
+- **A stream no longer starts muted every time, and stays that way.** Two
+  faults compounded. A page that has not been interacted with has no user
+  activation, so a browser refuses to autoplay WITH SOUND and `tbTryPlay()`
+  falls back to muted, which is correct and unavoidable. But that forced mute
+  fired `volumechange`, and the preference listener recorded it as *the host's
+  choice*, so `gn.tbStreamMuted` was set to true on the very first load and
+  every later load started silent on purpose. The same class of bug as the
+  alarm-ordering one fixed in v0.2115, in a second place.
+
+  The guard is the `autoMuted` marker on the element rather than a flag,
+  because `volumechange` fires asynchronously: a flag set and cleared around the
+  assignment is already false again by the time the listener runs. The marker
+  survives until it is deliberately cleared, which is exactly the window needed.
+
+- **The first interaction now gives the sound back.** Autoplay policy only
+  blocks audio *before* a page has been interacted with; afterwards, unmuting is
+  allowed. A timer display always gets touched, so `tbArmUnmuteOnGesture()`
+  binds one `pointerdown` / `touchend` / `keydown` listener that unmutes any
+  video the browser forced quiet, turning "always starts muted" into "muted for
+  the first few seconds". Only videos we muted are touched, and only when the
+  stored preference actually asks for sound, so a stream the host deliberately
+  silenced stays silent.
+
+  Covered by `qa-headless/unmute_logic.js`, which lifts the real listener body
+  out of `timer_beta.js` rather than mirroring it, so the test cannot drift from
+  what ships. The mirrored version of that test passed while the shipped code
+  was still broken, which is why it now reads the source.
+
+---
+
 ## [v0.2116] - 2026-08-27
 
 ### Fixed

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -1486,18 +1486,59 @@ function tbSetStreamVolPref(v) {
 // Autoplay WITH sound needs user activation, and a display that has been
 // clicked (Start) usually has it. Ask for sound first and fall back to muted
 // only if the browser actually refuses, rather than assuming it will.
+// True only while autoplay policy is forcing a mute on us. The preference
+// listener checks it for the same reason it checks STREAM_MUTED_BY_ALARM:
+// without it, the browser's refusal to autoplay with sound gets written down as
+// "the host wants this muted", and every later load starts silent for good.
+var STREAM_FORCING_MUTE = false;
+
 function tbTryPlay(vid) {
     var p;
     try { p = vid.play(); } catch (e) { return; }
     if (p && p.catch) {
         p.catch(function () {
             if (!vid.muted) {
+                // A page that has never been clicked has no user activation, so
+                // autoplay WITH SOUND is refused. Fall back to muted rather than
+                // showing a frozen frame, mark it, and let the first tap on the
+                // display restore the sound (see tbArmUnmuteOnGesture).
+                STREAM_FORCING_MUTE = true;
                 vid.muted = true;
+                vid.dataset.autoMuted = '1';
+                STREAM_FORCING_MUTE = false;
                 var q; try { q = vid.play(); } catch (e) { return; }
                 if (q && q.catch) q.catch(function () {});
             }
         });
     }
+}
+
+/* Give the host their sound back on the first real interaction.
+ *
+ * Autoplay policy only blocks sound BEFORE the page has been interacted with;
+ * once it has, unmuting is allowed. A timer display is always touched (the host
+ * starts the clock), so binding one listener turns "always starts muted" into
+ * "muted for the first few seconds". Only videos WE muted are touched, and only
+ * when the stored preference actually asks for sound. */
+var _unmuteArmed = false;
+function tbArmUnmuteOnGesture() {
+    if (_unmuteArmed) return;
+    _unmuteArmed = true;
+    var go = function () {
+        if (tbStreamMutePref()) return;      // the host chose silence; respect it
+        videoFrames.forEach(function (v) {
+            if (v.tagName !== 'VIDEO' || v.dataset.autoMuted !== '1') return;
+            // Marker first: unmuting here IS the host getting what they asked
+            // for, so the resulting volumechange should be recorded normally.
+            delete v.dataset.autoMuted;
+            v.muted = false;
+            try { v.volume = tbStreamVolPref(); } catch (e) {}
+            if (v.paused) { var q; try { q = v.play(); } catch (e) {} if (q && q.catch) q.catch(function () {}); }
+        });
+    };
+    ['pointerdown', 'touchend', 'keydown'].forEach(function (evt) {
+        document.addEventListener(evt, go, { passive: true });
+    });
 }
 
 // Dispose cached players the rebuilt tree no longer contains. Anything still
@@ -1684,10 +1725,21 @@ function buildCell(spec) {
                 // AND the next page load. Ignored while the alarm holds the
                 // channel, or ducking would be recorded as an intentional mute.
                 vid.addEventListener('volumechange', function () {
-                    if (STREAM_MUTED_BY_ALARM) return;   // the alarm's ramp, not the host
+                    // Neither the alarm's ramp nor an autoplay-forced mute is the
+                    // host expressing a preference; recording either makes the
+                    // stream come back silent forever.
+                    //
+                    // The autoMuted MARKER does that job rather than a flag,
+                    // because volumechange fires asynchronously: a flag set and
+                    // cleared around the assignment is already false again by the
+                    // time this runs. The marker survives until the gesture
+                    // handler clears it, which is exactly the window we need.
+                    if (STREAM_MUTED_BY_ALARM || STREAM_FORCING_MUTE) return;
+                    if (vid.dataset.autoMuted === '1') return;
                     tbSetStreamMutePref(vid.muted);
                     tbSetStreamVolPref(vid.volume);
                 });
+                tbArmUnmuteOnGesture();
             }
             if (window.TB_EMBED) vid.style.pointerEvents = 'none';
             inner.appendChild(vid);

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2116');
+define('APP_VERSION', '0.2117');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Reported from real use: "whenever a timer screen is started using the videostream, the videostream always starts muted."

## Two faults compounding

**One is unavoidable.** A page that has not been interacted with has no user activation, so browsers refuse to autoplay *with sound*. `tbTryPlay()` correctly falls back to muted rather than showing a frozen frame.

**One was a bug.** That forced mute fired `volumechange`, and the preference listener recorded it as **the host's choice**. So `gn.tbStreamMuted` was set to `true` on the very first load and every later load then started silent *on purpose*. This is the same class of bug as the alarm-ordering one fixed in v0.2115, in a second place I missed.

## The guard has to be a marker, not a flag

My first attempt set a `STREAM_FORCING_MUTE` flag around the assignment. That does not work: **`volumechange` fires asynchronously**, so the flag is already back to `false` by the time the listener runs. The `autoMuted` marker on the element survives until deliberately cleared, which is exactly the window needed.

## Giving the sound back

Autoplay policy only blocks audio *before* interaction; afterwards unmuting is allowed. A timer display always gets touched, so `tbArmUnmuteOnGesture()` binds one `pointerdown` / `touchend` / `keydown` listener that unmutes any video the browser forced quiet. "Always starts muted" becomes "muted for the first few seconds."

Only videos *we* muted are touched, and only when the stored preference asks for sound, so a stream the host deliberately silenced stays silent.

## The test had to be rewritten to be worth anything

```
PASS  fell back to muted so the picture still comes up
PASS  marked as auto-muted, not host-muted
PASS  forced mute NOT stored as preference
PASS  first interaction restored the sound
PASS  marker cleared
PASS  playback resumed
PASS  a deliberately muted stream is NOT unmuted by a gesture
```

Worth recording how this nearly went wrong. My first browser test called `window.tbTryPlay`, which is `undefined` because the file is IIFE-wrapped, so it asserted on a code path that never ran and passed vacuously. My second test hand-mirrored the preference listener, and **passed while the shipped code was still broken**, because I fixed the real listener and not the copy. `unmute_logic.js` now lifts the real listener body out of `timer_beta.js` with a regex, so it cannot drift from what ships.

`hls_persist_check.js` and `hls_fade_check.js` both re-run clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)