### PR TITLE
Retire mute/volume preferences poisoned by the pre-v0.2117 bug (v0.2118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2118] - 2026-08-27
+
+### Fixed
+
+- **Devices poisoned by the pre-v0.2117 mute bug now heal themselves.** That
+  bug wrote an autoplay-forced mute into `localStorage` as though the host had
+  chosen it. v0.2117 stopped new writes, but it could not undo the ones already
+  on people's machines, and the gesture unmute deliberately respects a stored
+  preference, so an affected browser had no way back: it opened muted, refused
+  to unmute on interaction, and looked exactly like the bug was never fixed.
+  Clearing site data was the only escape, which is not a thing to ask of anyone.
+
+  Both keys are now versioned (`gn.tbStreamMuted2`, `gn.tbStreamVolume2`) and
+  the originals are deleted on sight, so every stale value retires on the next
+  load without anyone touching browser settings.
+
+  The volume key is included because it fails the same way and is harder to
+  spot: a level captured while a fade was in flight could be stored as `0`,
+  which looks identical to a muted stream but is not fixed by unmuting. A
+  stored `0` is now treated as unset and reads back as full volume, on the
+  grounds that nobody deliberately sets a stream to silent-but-unmuted.
+
+  Covered by `qa-headless/mute_migrate_check.js`, which seeds both poisoned
+  values and asserts they are ignored and removed.
+
+---
+
 ## [v0.2117] - 2026-08-27
 
 ### Fixed

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -1465,22 +1465,41 @@ var videoCache = {};
 // The host's sound choice, remembered per device. Mirrors the classic timer's
 // gn.muteStreamDuringAlarms convention. Default UNMUTED: a stream nobody can
 // hear is not what anyone put on the display for.
+// Key is versioned (…2) on purpose. Before v0.2117 an autoplay-forced mute was
+// written here as though the host had chosen it, so any device that opened a
+// stream in that window carries a poisoned `true` that would keep the sound off
+// forever — and the gesture unmute correctly refuses to override a stored
+// preference, so it could never heal itself. Reading a new key retires those
+// values without asking anyone to clear site data; the old one is deleted on
+// sight so it does not linger.
 function tbStreamMutePref() {
-    try { return localStorage.getItem('gn.tbStreamMuted') === 'true'; } catch (e) { return false; }
+    try {
+        localStorage.removeItem('gn.tbStreamMuted');
+        return localStorage.getItem('gn.tbStreamMuted2') === 'true';
+    } catch (e) { return false; }
 }
 function tbSetStreamMutePref(m) {
-    try { localStorage.setItem('gn.tbStreamMuted', m ? 'true' : 'false'); } catch (e) {}
+    try { localStorage.setItem('gn.tbStreamMuted2', m ? 'true' : 'false'); } catch (e) {}
 }
 // The level as well as the switch. Now that the alarm ramps rather than mutes,
 // a host who turned the stream down to sit under table talk should find it
 // there next time instead of back at full.
+// Versioned alongside the mute key, and for the same reason: a level captured
+// mid-fade or during a forced mute could be stored as 0, which looks identical
+// to a muted stream but is NOT cleared by unmuting, so it would survive every
+// fix above. A stored 0 is also treated as unset — nobody deliberately sets a
+// stream to silent-but-unmuted, and reading it back as full volume is the
+// recoverable choice.
 function tbStreamVolPref() {
     var v;
-    try { v = parseFloat(localStorage.getItem('gn.tbStreamVolume')); } catch (e) { v = NaN; }
-    return (isNaN(v) || v < 0 || v > 1) ? 1 : v;
+    try {
+        localStorage.removeItem('gn.tbStreamVolume');
+        v = parseFloat(localStorage.getItem('gn.tbStreamVolume2'));
+    } catch (e) { v = NaN; }
+    return (isNaN(v) || v <= 0 || v > 1) ? 1 : v;
 }
 function tbSetStreamVolPref(v) {
-    try { localStorage.setItem('gn.tbStreamVolume', String(Math.max(0, Math.min(1, v)))); } catch (e) {}
+    try { localStorage.setItem('gn.tbStreamVolume2', String(Math.max(0, Math.min(1, v)))); } catch (e) {}
 }
 
 // Autoplay WITH sound needs user activation, and a display that has been

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2117');
+define('APP_VERSION', '0.2118');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Follow-up to v0.2117, reported as "on a clean browser load it is still starting muted."

## Why the previous fix wasn't enough

v0.2117 stopped *writing* an autoplay-forced mute into `localStorage` as though the host had chosen it. It could not undo the values already sitting on people's devices.

That left affected browsers with no way out. The gesture unmute deliberately respects a stored preference (a stream you muted on purpose must stay muted), so it saw `gn.tbStreamMuted=true`, concluded the host wanted silence, and did nothing. The stream opened muted, refused to unmute on interaction, and looked exactly as though the fix had never shipped. Clearing site data was the only escape, which is not something to ask of anyone using a timer at a poker table.

A new tab does not help either: `localStorage` is per-origin and persists.

## The fix

Both keys are versioned (`gn.tbStreamMuted2`, `gn.tbStreamVolume2`) and the originals deleted on read, so stale values retire on the next page load with no user action.

## Why the volume key is included

It fails the same way and is harder to notice. A level captured while an alarm fade was in flight could be stored as `0`, which is visually identical to a muted stream but is **not** fixed by unmuting: the speaker icon looks normal while the slider sits at zero. That is what the reporter's screenshot appeared to show.

A stored `0` is now treated as unset and reads back as full volume, on the grounds that nobody deliberately configures a stream to be silent-but-unmuted.

## Verified

```
PASS  poisoned gn.tbStreamMuted=true is ignored
PASS  poisoned gn.tbStreamVolume=0 reads back as full
PASS  old mute key deleted
PASS  old volume key deleted
```

`qa-headless/unmute_logic.js` re-runs clean (7/7), including that a deliberately muted stream is still not unmuted by a gesture.

Worth noting: I could not reproduce the original symptom in headless Chromium, which autoplays unmuted even with `--autoplay-policy=user-gesture-required`, so the forced-mute path never triggers there. The diagnosis came from reading the storage lifecycle and the reporter's screenshot rather than from a reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)