### PR TITLE
Trigger warm-up and fine control of the stream audio duck (v0.2119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,14 @@ All notable changes to GameNight are documented here.
   layout should duck the same way. Each key falls back to the previous hard-coded
   default when absent, so existing layouts are unchanged.
 
-  The four settings are editable from the right-click menu on the screen
-  background, beside **Screen shape** and **Panel colours**, as preset rows
-  matching that menu's idiom: duck depth (silence / 10% / 20% / 50%), fade down,
-  fade back and how long the duck holds. The saved layout still accepts any
-  value in range, so exact figures can be set by hand.
+  The four settings sit **in the Triggers panel**, above the trigger list, as a
+  plain sentence: *while an alarm plays, the video stream* drops to / fading down
+  over / staying down for / coming back over. They are visible on the panel
+  rather than tucked into a right-click menu, because these are tuned by ear and
+  a control nobody can find is a control nobody adjusts. Choosing a default
+  deletes the key rather than writing it, so a layout only carries what was
+  actually changed, and the saved layout still accepts any value in range for
+  exact figures set by hand.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,21 @@ All notable changes to GameNight are documented here.
   layout should duck the same way. Each key falls back to the previous hard-coded
   default when absent, so existing layouts are unchanged.
 
+  The four settings are editable from the right-click menu on the screen
+  background, beside **Screen shape** and **Panel colours**, as preset rows
+  matching that menu's idiom: duck depth (silence / 10% / 20% / 50%), fade down,
+  fade back and how long the duck holds. The saved layout still accepts any
+  value in range, so exact figures can be set by hand.
+
 ### Fixed
+
+- **A single-screen layout lost its whole-layout settings the moment it was
+  opened in the editor.** `normalizeLayout()` rebuilt the document from a
+  hand-written key list (`v`, `aspect`, `screens`), so anything not named there
+  was silently dropped: triggers, custom elements, shared styles and now the
+  stream audio settings. The new panels would have appeared to save and then
+  reverted. It now carries every whole-layout key across, and still does not
+  materialise absent ones as nulls.
 
 - **The QA sound hook fired before the sound was audible.** It sat at the top of
   `tbPlaySound()` and returned early, so with a warm-up it reported the sound as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,14 @@ All notable changes to GameNight are documented here.
   layout should duck the same way. Each key falls back to the previous hard-coded
   default when absent, so existing layouts are unchanged.
 
-  The four settings sit **in the Triggers panel**, above the trigger list, as a
-  plain sentence: *while an alarm plays, the video stream* drops to / fading down
-  over / staying down for / coming back over. They are visible on the panel
-  rather than tucked into a right-click menu, because these are tuned by ear and
-  a control nobody can find is a control nobody adjusts. Choosing a default
-  deletes the key rather than writing it, so a layout only carries what was
-  actually changed, and the saved layout still accepts any value in range for
-  exact figures set by hand.
+  The four settings sit **in the video stream cell's own settings**, directly
+  under the Stream URL, as a plain sentence: *while an alarm plays, this stream*
+  drops to / fading down over / staying down for / coming back over. They belong
+  with the stream they govern rather than in a right-click menu or a separate
+  panel, so nobody has to hunt for a setting attached to the thing already in
+  front of them. Choosing a default deletes the key rather than writing it, so a
+  layout only carries what was actually changed, and the saved layout still
+  accepts any value in range for exact figures set by hand.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2119] - 2026-08-27
+
+### Added
+
+- **Trigger warm-up: an alarm can now fade the stream down before it sounds.**
+  Previously the duck and the sound started together, so the alarm's first
+  moment landed while the stream was still at full volume — the "sudden" effect
+  the ducking was supposed to prevent. A sound action gains a **warm-up in
+  seconds** (`warmup`, 0-10, half-second steps, set in the trigger row next to
+  the sound). With one set, the stream ramps down over that period *first* and
+  the sound waits for the bottom of the ramp, arriving into audio that has
+  already made room. The duck window is extended by the same amount so the hold
+  still covers the sound rather than being eaten by the ramp. Left at 0, the
+  behaviour is exactly as before.
+
+- **Layout-level control over how the stream's audio behaves around an alarm.**
+  A `stream` block on the layout sets `fadeOut` and `fadeIn` (50-10000ms),
+  `hold` (500-60000ms, how long the duck lasts, previously a hard-coded 5s), and
+  `duckTo` (0-1). That last one is the interesting knob: ducking *to* a level
+  rather than to silence keeps the stream present under the alarm, where a full
+  drop can read as a dropout. These are layout-level rather than per-trigger
+  because they describe the room's sound, not any one event; every alarm in a
+  layout should duck the same way. Each key falls back to the previous hard-coded
+  default when absent, so existing layouts are unchanged.
+
+### Fixed
+
+- **The QA sound hook fired before the sound was audible.** It sat at the top of
+  `tbPlaySound()` and returned early, so with a warm-up it reported the sound as
+  instant and hid the very ordering the feature creates. It now fires in
+  `tbPlaySoundNow()`, at the moment the sound is actually heard.
+
+  Verified in Chromium against a live stream: with a 2s warm-up the sound fired
+  at 2002ms, the stream was already at the configured 0.20 duck level when it
+  did, and it got there through 34 intermediate volume steps rather than a cut.
+
+---
+
 ## [v0.2118] - 2026-08-27
 
 ### Fixed

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -701,11 +701,31 @@ var deviceOverride = null;
  * the classic timer carries over here. */
 var STREAM_MUTED_BY_ALARM = false;
 var STREAM_UNMUTE_TIMER = null;
-// Fade timings. Out fast enough to clear the way for the alarm, back in slow
+// Fade defaults. Out fast enough to clear the way for the alarm, back in slow
 // enough not to startle a room. Deliberately asymmetric: a duck that returns as
-// abruptly as it left is more noticeable than the duck itself.
+// abruptly as it left is more noticeable than the duck itself. A layout can
+// override any of these (see tbStreamCfg) without touching the defaults, so an
+// existing layout keeps behaving exactly as it did.
 var STREAM_FADE_OUT_MS = 250;
 var STREAM_FADE_IN_MS  = 600;
+var STREAM_HOLD_MS     = 5000;
+var STREAM_DUCK_TO     = 0;
+
+// Layout-level audio settings, read fresh each time because a layout can be
+// swapped under a running display.
+function tbStreamCfg() {
+    var c = (CURRENT_LAYOUT && CURRENT_LAYOUT.stream) || {};
+    var num = function (v, dflt, lo, hi) {
+        v = parseFloat(v);
+        return (isNaN(v) || v < lo || v > hi) ? dflt : v;
+    };
+    return {
+        fadeOut: num(c.fadeOut, STREAM_FADE_OUT_MS, 50, 10000),
+        fadeIn:  num(c.fadeIn,  STREAM_FADE_IN_MS,  50, 10000),
+        hold:    num(c.hold,    STREAM_HOLD_MS,     500, 60000),
+        duckTo:  num(c.duckTo,  STREAM_DUCK_TO,     0, 1)
+    };
+}
 
 /* Ramp a media element's volume instead of cutting it.
  *
@@ -732,7 +752,11 @@ function tbFadeVolume(vid, to, ms, done) {
     });
 }
 
-function tbStreamMute(on) {
+function tbStreamMute(on, cfg, fadeOutMs) {
+    cfg = cfg || tbStreamCfg();
+    // fadeOutMs lets a trigger's warm-up stretch the ramp for one alarm without
+    // changing the layout's own setting.
+    var outMs = (fadeOutMs === undefined) ? cfg.fadeOut : fadeOutMs;
     videoFrames.forEach(function (frame) {
         if (!frame.isConnected || !frame.src) return;
         if (frame.tagName === 'VIDEO') {
@@ -746,7 +770,12 @@ function tbStreamMute(on) {
                     frame.dataset.preAlarmVol   = String(frame.volume);
                 }
                 if (frame.muted) return;             // nothing audible to duck
-                tbFadeVolume(frame, 0, STREAM_FADE_OUT_MS, function () { frame.muted = true; });
+                // Ducking TO a level rather than to zero keeps the stream
+                // present under the alarm; a full drop can read as a dropout.
+                // Only mute outright when the target really is silence.
+                tbFadeVolume(frame, cfg.duckTo, outMs, function () {
+                    if (cfg.duckTo <= 0) frame.muted = true;
+                });
             } else {
                 var wasMuted = frame.dataset.preAlarmMuted === '1';
                 var vol = parseFloat(frame.dataset.preAlarmVol);
@@ -755,8 +784,8 @@ function tbStreamMute(on) {
                 delete frame.dataset.preAlarmVol;
                 if (wasMuted) return;                // host had it off; leave it
                 frame.muted = false;
-                try { frame.volume = 0; } catch (e) {}
-                tbFadeVolume(frame, vol, STREAM_FADE_IN_MS);
+                if (cfg.duckTo <= 0) { try { frame.volume = 0; } catch (e) {} }
+                tbFadeVolume(frame, vol, cfg.fadeIn);
             }
             return;
         }
@@ -777,41 +806,64 @@ function tbStreamMute(on) {
         } catch (e) {}
     });
 }
-function tbMuteStreamForAlarm(durationMs) {
+function tbMuteStreamForAlarm(durationMs, fadeOutMs) {
     if (!videoFrames.length) return;
     try {
         if (localStorage.getItem('gn.muteStreamDuringAlarms') === 'false') return;
     } catch (e) {}
+    var cfg = tbStreamCfg();
     // Flag BEFORE muting, not after: muting a <video> fires volumechange, and
     // the preference listener must be able to tell the alarm's ducking from the
     // host reaching for the volume. Set afterwards, one alarm would be recorded
     // as "the host wants this muted" and every later load would start silent.
     STREAM_MUTED_BY_ALARM = true;
-    tbStreamMute(true);
+    tbStreamMute(true, cfg, fadeOutMs);
     if (STREAM_UNMUTE_TIMER) clearTimeout(STREAM_UNMUTE_TIMER);
     STREAM_UNMUTE_TIMER = setTimeout(function () {
         if (STREAM_MUTED_BY_ALARM) {
-            tbStreamMute(false);
+            tbStreamMute(false, cfg);
             // Hold the flag until the ramp FINISHES, not merely until the call
             // returns. Every step of the fade fires volumechange, and the
             // preference listener must not read the ramp as the host reaching
             // for the volume; it would store a half-faded level as their
             // setting and the stream would come back quieter after every alarm.
-            setTimeout(function () { STREAM_MUTED_BY_ALARM = false; }, STREAM_FADE_IN_MS + 80);
+            setTimeout(function () { STREAM_MUTED_BY_ALARM = false; }, cfg.fadeIn + 80);
         }
         STREAM_UNMUTE_TIMER = null;
     }, durationMs);
 }
 
-function tbPlaySound(val) {
+/* Play a trigger sound, optionally after a WARM-UP.
+ *
+ * Without a warm-up the duck and the alarm start together, so the alarm's first
+ * moment lands while the stream is still at full volume — the exact "sudden"
+ * effect this exists to remove. With one, the stream ramps down over `warmupMs`
+ * FIRST and the sound waits for it, arriving into audio that has already made
+ * room. The duck window is extended by the same amount so the hold still covers
+ * the sound itself rather than being eaten by the ramp. */
+function tbPlaySound(val, warmupMs) {
     if (!soundOn) return;
     if (typeof val !== 'string') return;
+    var cfg = tbStreamCfg();
+    warmupMs = Math.max(0, Math.min(10000, +warmupMs || 0));
+    if (warmupMs > 0 && videoFrames.length) {
+        // Ramp over the warm-up rather than the layout's normal fade, hold for
+        // the warm-up plus the usual window, and delay the sound to the bottom
+        // of the ramp.
+        tbMuteStreamForAlarm(warmupMs + cfg.hold, warmupMs);
+        setTimeout(function () { tbPlaySoundNow(val); }, warmupMs);
+        return;
+    }
+    tbMuteStreamForAlarm(cfg.hold);
+    tbPlaySoundNow(val);
+}
+
+function tbPlaySoundNow(val) {
+    // The QA hook fires HERE, not at tbPlaySound, so it observes the moment the
+    // sound is actually heard. With a warm-up that is after the ramp, and a hook
+    // placed earlier would report the sound as instant and hide the very
+    // ordering this feature exists to create.
     if (soundHook) { soundHook(val); return; }   // heard, not played
-    // Duck any streaming cells while the sound plays. Presets run ~1-2s and
-    // uploaded sounds are capped short; a flat 5s window (sound + padding)
-    // matches the classic timer's per-alarm windows without tracking each
-    // sound's real length. Reentrant — an overlapping sound extends the mute.
-    tbMuteStreamForAlarm(5000);
     if (val.indexOf('preset:') === 0) {
         var segs = TB_PRESETS[val.slice(7)];
         if (!segs) return;
@@ -878,7 +930,9 @@ function runTriggerActions(list) {
     for (var i = 0; i < (list || []).length; i++) {
         var act = list[i];
         if (!act || typeof act !== 'object') continue;
-        if (act.sound) tbPlaySound(act.sound);
+        // warmup is in SECONDS in the layout (that is the unit an author thinks
+        // in); tbPlaySound wants ms.
+        if (act.sound) tbPlaySound(act.sound, (parseFloat(act.warmup) || 0) * 1000);
         if (act.flash) {
             root.classList.remove('tb-flash');
             void root.offsetWidth;                    // restart the animation
@@ -2770,6 +2824,9 @@ if (window.TB_EMBED) {
         runActions: function (list) { runTriggerActions(list); },
         // QA hooks: the engine is IIFE-wrapped, so the suite observes sound
         // policy and would-be playback here instead of stubbing internals.
+        // Exposed so a test can assert the warm-up ordering (ramp first, sound
+        // second) without waiting on real audio.
+        streamCfg: function () { return tbStreamCfg(); },
         sound: {
             on:   function () { return soundOn; },
             set:  function (v) { soundOn = !!v; },

--- a/www/timer_beta_dl.php
+++ b/www/timer_beta_dl.php
@@ -436,6 +436,16 @@ function pk_lo_trigger($t, array $screenNames): ?array {
             $presets = ['buzzer','chime','casino','horn','countdown','double','descending','five3s','tick','pulse','chirp','gentle'];
             if (preg_match('/^preset:([a-z0-9]+)$/', $v, $m) && in_array($m[1], $presets, true)) $act['sound'] = $v;
             elseif (preg_match('#^/uploads/timer_sounds/[A-Za-z0-9._-]{1,160}$#', $v)) $act['sound'] = $v;
+            // Warm-up: ramp the stream down over this many seconds BEFORE the
+            // sound plays, so the alarm lands in already-quiet audio instead of
+            // cutting across a loud stream. Deliberately NOT the same key as the
+            // takeover's `seconds`, which means something else entirely on the
+            // same action object. Fractional, because half a second is a real
+            // choice here and whole seconds are a coarse dial.
+            if (isset($act['sound'])) {
+                $w0 = pk_lo_num($a['warmup'] ?? 0, 0, 10);
+                if ($w0 !== null && $w0 > 0) $act['warmup'] = round((float)$w0, 2);
+            }
         }
         if (isset($a['takeover']) && is_string($a['takeover']) && in_array($a['takeover'], $screenNames, true)) {
             $act['takeover'] = $a['takeover'];
@@ -481,6 +491,25 @@ function pk_layout_sanitize($doc, array &$err): ?array {
     // cropped to fill the screen while the text spreads across all of it.
     // Locking the ratio letterboxes both together instead.
     if (isset($doc['aspect'])) { $n = pk_lo_num($doc['aspect'], 0.4, 4.0); if ($n !== null) $out['aspect'] = $n; }
+
+    // How the video stream's audio behaves around an alarm. Layout-level rather
+    // than per-trigger because it is a property of the room's sound, not of any
+    // one event: every alarm in a layout should duck the same way. Each key
+    // falls back to the renderer's default when absent, so an old layout keeps
+    // behaving exactly as it did.
+    if (isset($doc['stream']) && is_array($doc['stream'])) {
+        $st = [];
+        // Ramp lengths in ms. Floors are not zero: an instant cut is the thing
+        // this whole feature exists to avoid.
+        if (isset($doc['stream']['fadeOut'])) { $n = pk_lo_num($doc['stream']['fadeOut'], 50, 10000); if ($n !== null) $st['fadeOut'] = (int)$n; }
+        if (isset($doc['stream']['fadeIn']))  { $n = pk_lo_num($doc['stream']['fadeIn'], 50, 10000); if ($n !== null) $st['fadeIn']  = (int)$n; }
+        // How long the duck holds once down, covering the sound plus padding.
+        if (isset($doc['stream']['hold']))    { $n = pk_lo_num($doc['stream']['hold'], 500, 60000); if ($n !== null) $st['hold'] = (int)$n; }
+        // Duck TO this level rather than to silence. 0.15 under a voice is
+        // often better than nothing at all, which can read as a dropout.
+        if (isset($doc['stream']['duckTo']))  { $n = pk_lo_num($doc['stream']['duckTo'], 0, 1); if ($n !== null) $st['duckTo'] = round((float)$n, 3); }
+        if ($st) $out['stream'] = $st;
+    }
 
     // Triggers: fire actions when a condition BECOMES true. Same `when`
     // grammar as everything else; actions whitelisted by key; sounds may only

--- a/www/timer_beta_edit.css
+++ b/www/timer_beta_edit.css
@@ -194,6 +194,15 @@
 .tbe-inline { display: inline-flex; align-items: center; gap: .3rem; }
 .tbe-inline > span { color: #94a3b8; font-size: .74rem; white-space: nowrap; }
 
+/* Alarm ducking, shown inline at the top of the Triggers panel. Visible on the
+   panel rather than hidden behind a right-click, because these are tuned by ear
+   and a control nobody can find is a control nobody adjusts. */
+.tbe-duck { border: 1px solid #1e293b; border-radius: 8px; padding: .5rem .6rem; margin: .5rem 0 .7rem; background: #0f172a; }
+.tbe-duck-head { color: #94a3b8; font-size: .76rem; margin-bottom: .35rem; }
+.tbe-duck-row { display: flex; align-items: center; justify-content: space-between; gap: .5rem; margin: .22rem 0; }
+.tbe-duck-row > span { color: #cbd5e1; font-size: .78rem; }
+.tbe-duck-row select { flex: 0 0 auto; min-width: 7.5rem; }
+
 /* Right-click menu for a layout node. Body-level so it escapes both the tree's
    scroll box and the preview iframe. */
 .tbe-menu { display: none; position: fixed; z-index: 4000; background: #fff;

--- a/www/timer_beta_edit.css
+++ b/www/timer_beta_edit.css
@@ -189,6 +189,10 @@
 /* Explanatory copy inside an inspector field (what a QR cell does, and why the
    preview shows a placeholder rather than a scannable code). */
 .tbe-note { color: #64748b; font-size: .74rem; line-height: 1.45; margin-top: .2rem; }
+/* A small labelled control that sits inline in a trigger action row, so the
+   warm-up reads as part of the sound rather than as a separate setting. */
+.tbe-inline { display: inline-flex; align-items: center; gap: .3rem; }
+.tbe-inline > span { color: #94a3b8; font-size: .74rem; white-space: nowrap; }
 
 /* Right-click menu for a layout node. Body-level so it escapes both the tree's
    scroll box and the preview iframe. */

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -1045,6 +1045,65 @@ function triggerLabel(tg) {
     return when + (acts.length ? ' — ' + acts.join(', ') : '');
 }
 
+/* Whole-layout audio behaviour for alarms, rendered inline in the Triggers
+ * panel. Selects rather than a submenu: these are settings someone tunes by
+ * ear, and a control they cannot see is a control they will not tune. Picking
+ * the default deletes the key, so a layout only carries what was changed. */
+function streamDuckPanel() {
+    var wrap = document.createElement('div');
+    wrap.className = 'tbe-duck';
+    var h = document.createElement('div');
+    h.className = 'tbe-duck-head';
+    h.textContent = 'While an alarm plays, the video stream…';
+    wrap.appendChild(h);
+
+    function row(label, key, dflt, opts, title) {
+        var lab = document.createElement('label');
+        lab.className = 'tbe-duck-row';
+        if (title) lab.title = title;
+        var sp = document.createElement('span');
+        sp.textContent = label;
+        var sel = document.createElement('select');
+        opts.forEach(function (o) {
+            var op = document.createElement('option');
+            op.value = String(o[0]); op.textContent = o[1];
+            sel.appendChild(op);
+        });
+        var st = LAYOUT.stream || {};
+        sel.value = String(st[key] !== undefined ? st[key] : dflt);
+        sel.addEventListener('change', function () {
+            pushUndo();
+            var v = parseFloat(sel.value);
+            var s2 = LAYOUT.stream || (LAYOUT.stream = {});
+            if (v === dflt) delete s2[key]; else s2[key] = v;
+            if (!Object.keys(LAYOUT.stream).length) delete LAYOUT.stream;
+            refresh(true);
+        });
+        lab.appendChild(sp); lab.appendChild(sel);
+        wrap.appendChild(lab);
+    }
+
+    row('drops to', 'duckTo', 0,
+        [[0, 'silence'], [0.1, '10% volume'], [0.2, '20% volume'], [0.5, 'half volume']],
+        'Ducking to a level rather than to silence keeps the stream present under the alarm. A full drop can sound like the feed died.');
+    row('fading down over', 'fadeOut', 250,
+        [[100, '0.1s'], [250, '0.25s'], [600, '0.6s'], [1200, '1.2s']],
+        'How long the stream takes to get quiet once an alarm fires.');
+    row('staying down for', 'hold', 5000,
+        [[3000, '3s'], [5000, '5s'], [8000, '8s'], [12000, '12s']],
+        'How long the duck holds. Too short and the stream returns over the tail of the alarm.');
+    row('coming back over', 'fadeIn', 600,
+        [[300, '0.3s'], [600, '0.6s'], [1200, '1.2s'], [2500, '2.5s']],
+        'Deliberately slower than the fade down by default: a duck that returns as abruptly as it left draws more attention than the duck.');
+
+    var tip = document.createElement('div');
+    tip.className = 'tbe-note';
+    tip.textContent = 'Set a warm-up on a sound below to fade the stream down BEFORE that alarm '
+                    + 'sounds, so it does not cut across a loud stream.';
+    wrap.appendChild(tip);
+    return wrap;
+}
+
 function renderTriggers() {
     if (!triggersPane) return;
     triggersPane.textContent = '';
@@ -1070,6 +1129,12 @@ function renderTriggers() {
     note.textContent = 'Fire ONCE each time the condition becomes true — a sound, a screen '
                      + 'takeover, a flash, a spoken line. Screens opened from the QR start muted.';
     box.appendChild(note);
+
+    // How alarms treat a video cell's audio. It belongs HERE, in front of
+    // whoever is editing alarms, rather than buried in a right-click menu they
+    // would have to find by accident. Whole-layout: every alarm ducks the same
+    // way, so it sits above the trigger list rather than inside each row.
+    box.appendChild(streamDuckPanel());
 
     LAYOUT.triggers.forEach(function (tg, ix) {
         if (!Array.isArray(tg['do'])) tg['do'] = [];
@@ -2203,56 +2268,6 @@ function openNodeMenu(path, x, y) {
             addRow('Let the artwork show through', !on, function () { setPanelColours(false); });
         });
 
-        // How a video cell's audio behaves when an alarm fires. Whole-layout,
-        // like the two above: every alarm in a layout should duck the same way.
-        // Presets rather than number boxes to match the rest of this menu; the
-        // saved layout accepts any value in range for exact tuning by hand.
-        function streamCfgVal(key, dflt) {
-            var st = LAYOUT.stream;
-            return (st && st[key] !== undefined) ? +st[key] : dflt;
-        }
-        function setStreamCfg(key, v, dflt) {
-            return edit(function () {
-                var st = LAYOUT.stream || (LAYOUT.stream = {});
-                if (v === dflt) delete st[key]; else st[key] = v;
-                // Never leave an empty object behind in the saved layout.
-                if (LAYOUT.stream && !Object.keys(LAYOUT.stream).length) delete LAYOUT.stream;
-            })();
-        }
-        sub('Alarm ducking: depth', function (panel, addRow) {
-            // Ducking to a LEVEL rather than to silence keeps the stream present
-            // under the alarm; a full drop can read as the feed dying.
-            var cur = streamCfgVal('duckTo', 0);
-            addRow('All the way to silence', cur === 0,   function () { setStreamCfg('duckTo', 0, 0); });
-            addRow('Very quiet (10%)',       cur === 0.1, function () { setStreamCfg('duckTo', 0.1, 0); });
-            addRow('Quiet (20%)',            cur === 0.2, function () { setStreamCfg('duckTo', 0.2, 0); });
-            addRow('Half volume (50%)',      cur === 0.5, function () { setStreamCfg('duckTo', 0.5, 0); });
-        });
-        sub('Alarm ducking: fade down', function (panel, addRow) {
-            var cur = streamCfgVal('fadeOut', 250);
-            addRow('Snappy (0.1s)',        cur === 100,  function () { setStreamCfg('fadeOut', 100, 250); });
-            addRow('Normal (0.25s)',       cur === 250,  function () { setStreamCfg('fadeOut', 250, 250); });
-            addRow('Gentle (0.6s)',        cur === 600,  function () { setStreamCfg('fadeOut', 600, 250); });
-            addRow('Slow (1.2s)',          cur === 1200, function () { setStreamCfg('fadeOut', 1200, 250); });
-        });
-        sub('Alarm ducking: fade back', function (panel, addRow) {
-            // Deliberately slower than the fade down by default: a duck that
-            // returns as abruptly as it left draws more attention than the duck.
-            var cur = streamCfgVal('fadeIn', 600);
-            addRow('Quick (0.3s)',         cur === 300,  function () { setStreamCfg('fadeIn', 300, 600); });
-            addRow('Normal (0.6s)',        cur === 600,  function () { setStreamCfg('fadeIn', 600, 600); });
-            addRow('Gentle (1.2s)',        cur === 1200, function () { setStreamCfg('fadeIn', 1200, 600); });
-            addRow('Slow (2.5s)',          cur === 2500, function () { setStreamCfg('fadeIn', 2500, 600); });
-        });
-        sub('Alarm ducking: how long', function (panel, addRow) {
-            // Covers the sound plus padding. Too short and the stream comes
-            // back over the tail of the alarm.
-            var cur = streamCfgVal('hold', 5000);
-            addRow('3 seconds',  cur === 3000,  function () { setStreamCfg('hold', 3000, 5000); });
-            addRow('5 seconds',  cur === 5000,  function () { setStreamCfg('hold', 5000, 5000); });
-            addRow('8 seconds',  cur === 8000,  function () { setStreamCfg('hold', 8000, 5000); });
-            addRow('12 seconds', cur === 12000, function () { setStreamCfg('hold', 12000, 5000); });
-        });
     }
 
     if (container) {

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -26,8 +26,18 @@ var editScreenIndex = 0;       // which screen the tree/inspector edit
 function normalizeLayout() {
     if (!LAYOUT) return;
     if (!Array.isArray(LAYOUT.screens) || !LAYOUT.screens.length) {
-        LAYOUT = { v: LAYOUT.v || 1, aspect: LAYOUT.aspect,
-                   screens: [{ name: 'Main', bg: LAYOUT.bg || null, root: LAYOUT.root || { col: [] } }] };
+        // Carry every whole-layout key across, not just aspect. Rebuilding from
+        // a hand-written list silently DROPPED anything not named here, so a
+        // single-screen layout lost its triggers, custom elements and stream
+        // audio settings the moment it was opened in the editor.
+        var carried = { v: LAYOUT.v || 1, aspect: LAYOUT.aspect,
+                        triggers: LAYOUT.triggers, customElements: LAYOUT.customElements,
+                        styles: LAYOUT.styles, stream: LAYOUT.stream,
+                        screens: [{ name: 'Main', bg: LAYOUT.bg || null, root: LAYOUT.root || { col: [] } }] };
+        Object.keys(carried).forEach(function (k) {
+            if (carried[k] === undefined || carried[k] === null) delete carried[k];
+        });
+        LAYOUT = carried;
         if (!LAYOUT.aspect) delete LAYOUT.aspect;
     }
     if (editScreenIndex >= LAYOUT.screens.length) editScreenIndex = 0;
@@ -2191,6 +2201,57 @@ function openNodeMenu(path, x, y) {
             var on = panelColoursOn();
             addRow('Keep the painted panels', on, function () { setPanelColours(true); });
             addRow('Let the artwork show through', !on, function () { setPanelColours(false); });
+        });
+
+        // How a video cell's audio behaves when an alarm fires. Whole-layout,
+        // like the two above: every alarm in a layout should duck the same way.
+        // Presets rather than number boxes to match the rest of this menu; the
+        // saved layout accepts any value in range for exact tuning by hand.
+        function streamCfgVal(key, dflt) {
+            var st = LAYOUT.stream;
+            return (st && st[key] !== undefined) ? +st[key] : dflt;
+        }
+        function setStreamCfg(key, v, dflt) {
+            return edit(function () {
+                var st = LAYOUT.stream || (LAYOUT.stream = {});
+                if (v === dflt) delete st[key]; else st[key] = v;
+                // Never leave an empty object behind in the saved layout.
+                if (LAYOUT.stream && !Object.keys(LAYOUT.stream).length) delete LAYOUT.stream;
+            })();
+        }
+        sub('Alarm ducking: depth', function (panel, addRow) {
+            // Ducking to a LEVEL rather than to silence keeps the stream present
+            // under the alarm; a full drop can read as the feed dying.
+            var cur = streamCfgVal('duckTo', 0);
+            addRow('All the way to silence', cur === 0,   function () { setStreamCfg('duckTo', 0, 0); });
+            addRow('Very quiet (10%)',       cur === 0.1, function () { setStreamCfg('duckTo', 0.1, 0); });
+            addRow('Quiet (20%)',            cur === 0.2, function () { setStreamCfg('duckTo', 0.2, 0); });
+            addRow('Half volume (50%)',      cur === 0.5, function () { setStreamCfg('duckTo', 0.5, 0); });
+        });
+        sub('Alarm ducking: fade down', function (panel, addRow) {
+            var cur = streamCfgVal('fadeOut', 250);
+            addRow('Snappy (0.1s)',        cur === 100,  function () { setStreamCfg('fadeOut', 100, 250); });
+            addRow('Normal (0.25s)',       cur === 250,  function () { setStreamCfg('fadeOut', 250, 250); });
+            addRow('Gentle (0.6s)',        cur === 600,  function () { setStreamCfg('fadeOut', 600, 250); });
+            addRow('Slow (1.2s)',          cur === 1200, function () { setStreamCfg('fadeOut', 1200, 250); });
+        });
+        sub('Alarm ducking: fade back', function (panel, addRow) {
+            // Deliberately slower than the fade down by default: a duck that
+            // returns as abruptly as it left draws more attention than the duck.
+            var cur = streamCfgVal('fadeIn', 600);
+            addRow('Quick (0.3s)',         cur === 300,  function () { setStreamCfg('fadeIn', 300, 600); });
+            addRow('Normal (0.6s)',        cur === 600,  function () { setStreamCfg('fadeIn', 600, 600); });
+            addRow('Gentle (1.2s)',        cur === 1200, function () { setStreamCfg('fadeIn', 1200, 600); });
+            addRow('Slow (2.5s)',          cur === 2500, function () { setStreamCfg('fadeIn', 2500, 600); });
+        });
+        sub('Alarm ducking: how long', function (panel, addRow) {
+            // Covers the sound plus padding. Too short and the stream comes
+            // back over the tail of the alarm.
+            var cur = streamCfgVal('hold', 5000);
+            addRow('3 seconds',  cur === 3000,  function () { setStreamCfg('hold', 3000, 5000); });
+            addRow('5 seconds',  cur === 5000,  function () { setStreamCfg('hold', 5000, 5000); });
+            addRow('8 seconds',  cur === 8000,  function () { setStreamCfg('hold', 8000, 5000); });
+            addRow('12 seconds', cur === 12000, function () { setStreamCfg('hold', 12000, 5000); });
         });
     }
 

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -1054,7 +1054,7 @@ function streamDuckPanel() {
     wrap.className = 'tbe-duck';
     var h = document.createElement('div');
     h.className = 'tbe-duck-head';
-    h.textContent = 'While an alarm plays, the video stream…';
+    h.textContent = 'While an alarm plays, this stream…';
     wrap.appendChild(h);
 
     function row(label, key, dflt, opts, title) {
@@ -1098,8 +1098,8 @@ function streamDuckPanel() {
 
     var tip = document.createElement('div');
     tip.className = 'tbe-note';
-    tip.textContent = 'Set a warm-up on a sound below to fade the stream down BEFORE that alarm '
-                    + 'sounds, so it does not cut across a loud stream.';
+    tip.textContent = 'Applies to every alarm in this layout. Set a warm-up on a trigger\u2019s '
+                    + 'sound to fade down BEFORE that alarm plays, so it does not cut across a loud stream.';
     wrap.appendChild(tip);
     return wrap;
 }
@@ -1129,12 +1129,6 @@ function renderTriggers() {
     note.textContent = 'Fire ONCE each time the condition becomes true — a sound, a screen '
                      + 'takeover, a flash, a spoken line. Screens opened from the QR start muted.';
     box.appendChild(note);
-
-    // How alarms treat a video cell's audio. It belongs HERE, in front of
-    // whoever is editing alarms, rather than buried in a right-click menu they
-    // would have to find by accident. Whole-layout: every alarm ducks the same
-    // way, so it sits above the trigger list rather than inside each row.
-    box.appendChild(streamDuckPanel());
 
     LAYOUT.triggers.forEach(function (tg, ix) {
         if (!Array.isArray(tg['do'])) tg['do'] = [];
@@ -1758,6 +1752,11 @@ function renderInspector() {
             vCheck();
             insp.appendChild(field('Stream URL', vu));
             insp.appendChild(vErr);
+            // The stream's own audio behaviour, with the stream. It was in the
+            // Triggers panel and before that a right-click menu; both made
+            // someone hunt for a setting that plainly belongs to the thing they
+            // are already looking at.
+            insp.appendChild(streamDuckPanel());
             insp.appendChild(field('Weight (share of space)', numInput(node.weight, 0, 50, 0.1, function (v) { setOrDelete(node, 'weight', v); })));
             insp.appendChild(field('Show when', condEditor(cell.when, function (v) { pushUndo(); setOrDelete(cell, 'when', v); refresh(true); })));
             var rmV = document.createElement('button'); rmV.className = 'tbe-mini tbe-mini-danger';

--- a/www/timer_beta_edit.js
+++ b/www/timer_beta_edit.js
@@ -1228,6 +1228,32 @@ function triggerActionRow(tg, act, ai) {
             pushUndo(); act.sound = snd.value; refresh(true);
         });
         row.appendChild(snd);
+
+        // Warm-up: ramp the stream down BEFORE this sound plays, so the alarm
+        // arrives into audio that has already made room instead of cutting
+        // across it. 0 keeps the old behaviour of both starting together.
+        var warmWrap = document.createElement('label');
+        warmWrap.className = 'tbe-inline';
+        warmWrap.title = 'Seconds to fade the video stream down BEFORE this sound plays. '
+                       + '0 = sound and fade start together (can sound abrupt).';
+        var warmLbl = document.createElement('span');
+        warmLbl.textContent = 'warm-up';
+        var warm = document.createElement('input');
+        warm.type = 'number'; warm.min = '0'; warm.max = '10'; warm.step = '0.5';
+        warm.style.width = '4.2rem';
+        warm.value = act.warmup === undefined ? '0' : String(act.warmup);
+        warm.addEventListener('change', function () {
+            pushUndo();
+            var v = parseFloat(warm.value);
+            if (!isFinite(v) || v <= 0) { delete act.warmup; warm.value = '0'; }
+            else { act.warmup = Math.min(10, Math.round(v * 2) / 2); warm.value = String(act.warmup); }
+            refresh(true);
+        });
+        warmWrap.appendChild(warmLbl); warmWrap.appendChild(warm);
+        row.appendChild(warmWrap);
+        var warmUnit = document.createElement('span');
+        warmUnit.className = 'tbe-note'; warmUnit.textContent = 's';
+        row.appendChild(warmUnit);
     } else if (type === 'takeover') {
         var scr = document.createElement('select');
         (LAYOUT.screens || []).forEach(function (sc) {

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2118');
+define('APP_VERSION', '0.2119');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Reported: "when a trigger fires, it needs a warm up... audio is suddenly going into the trigger alarm."

## The cause

The duck and the sound started at the same instant. The fade-out takes 250ms, so the alarm's opening moment always landed on a stream still at or near full volume. Ducking existed but was always a step behind the thing it was ducking for.

## Warm-up

A sound action gains **`warmup`, in seconds** (0-10, half-second steps), set inline in the trigger row beside the sound. With one set:

1. the stream ramps down over the warm-up period
2. the sound fires at the bottom of the ramp
3. the duck window extends by the warm-up, so the hold still covers the sound rather than being consumed by the ramp

Left at 0 the behaviour is identical to before, so no existing layout changes.

Deliberately **not** reusing the `seconds` key, which already means "how long to show the takeover screen" on the same action object.

## Fine control, at layout level

A `stream` block replaces four hard-coded constants:

| key | range | was |
|---|---|---|
| `fadeOut` | 50-10000ms | 250 |
| `fadeIn` | 50-10000ms | 600 |
| `hold` | 500-60000ms | 5000 |
| `duckTo` | 0-1 | 0 |

`duckTo` is the interesting one: ducking *to* a level rather than to silence keeps the stream present underneath the alarm, where a full drop can read as a dropout.

These sit on the layout rather than on each trigger because they describe the room's sound, not any one event — every alarm in a layout should duck the same way. Each key falls back to its old default when absent.

## A bug the feature exposed

The QA sound hook sat at the top of `tbPlaySound()` and returned early, so with a warm-up it reported the sound as instant and hid the exact ordering being introduced. My first test passed for that reason. The hook now fires in `tbPlaySoundNow()`, when the sound is genuinely audible.

## Verified

Chromium against a live stream, 2s warm-up, layout overrides applied:

```
PASS  layout stream settings honoured: {"fadeOut":300,"fadeIn":900,"hold":3000,"duckTo":0.2}
PASS  sound fired
PASS  sound WAITED for the ramp (2002ms, warm-up was 2000ms)
PASS  stream already quiet when the sound fired (vol=0.20)
PASS  volume ramped through intermediate values (34 samples)
```

Server round-trip through `save_layout` confirms the fields persist exactly and out-of-range values clamp to the bounds (`999999 -> 10000`, `duckTo 5 -> 1`, `warmup 99 -> 10`), consistent with `aspect` and the other numeric fields.

`hls_fade_check.js` and `hls_persist_check.js` both re-run clean. Both had stale assertions against the pre-v0.2118 storage key names, which I had missed when renaming them; those are corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)