### PR TITLE
A rejected stream URL no longer removes the video cell (v0.2120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2120] - 2026-08-27
+
+### Fixed
+
+- **A rejected stream URL no longer destroys the video cell.** `pk_lo_cell()`
+  set `video` only when the URL survived validation, so a bad paste left the
+  cell with no `video` key at all: it stopped being a video cell and came back
+  as text. The author lost the cell, not just the URL. A rejected URL now stores
+  an empty string, keeping it a video cell that draws its placeholder and still
+  offers the Stream URL field to correct.
+
+- **The editor and the server disagreed about `http://` links.**
+  `mediaStreamUrl()` accepted an `http` URL and silently rewrote it to `https`,
+  so the editor showed a green tick while `pk_lo_stream_url()` rejected the very
+  same string on save. Combined with the bug above, pasting an `http` link
+  looked accepted and then removed the cell. The rewrite was wishful in any
+  case: a host serving plain `http` generally has no `https` listener, so the
+  upgraded URL could not have played either. The client now requires `https`,
+  exactly as the server does, and `diagnose()` explains why.
+
+  Covered by `qa-headless/stream_url_agree_check.js`, which runs the same five
+  URLs through the shipped client function and the shipped server function and
+  asserts both reach the same verdict.
+
+---
+
 ## [v0.2119] - 2026-08-27
 
 ### Added

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -1470,9 +1470,13 @@ function mediaStreamUrl(raw) {
     if (!raw) return '';
     var u;
     try { u = new URL(String(raw).trim()); } catch (e) { return ''; }
-    if (u.protocol !== 'https:' && u.protocol !== 'http:') return '';
+    // https ONLY, matching pk_lo_stream_url exactly. This used to accept http
+    // and silently rewrite it to https, which told the author their link was
+    // fine while the server rejected the very same string on save. It was also
+    // wishful: a host serving plain http usually has no https listener at all,
+    // so the rewritten URL could not have played either.
+    if (u.protocol !== 'https:') return '';
     if (!/\.(m3u8|mp4|m4v|webm)$/i.test(u.pathname)) return '';
-    u.protocol = 'https:';   // never mixed content on an https page
     return u.toString();
 }
 

--- a/www/timer_beta_dl.php
+++ b/www/timer_beta_dl.php
@@ -262,7 +262,16 @@ function pk_lo_cell($cell, array &$err): ?array {
     if (isset($cell['qr']) && in_array($cell['qr'], ['display'], true)) $out['qr'] = $cell['qr'];
     // Streaming video: the raw URL, kept only for recognised services (the
     // renderer normalizes it into the actual embed URL — see pk_lo_stream_url).
-    if (isset($cell['video'])) { $v = pk_lo_stream_url($cell['video']); if ($v !== null) $out['video'] = $v; }
+    // A REJECTED url must not take the cell with it. Setting `video` only on
+    // success meant a bad paste (an http:// link, a typo) left the cell with no
+    // `video` key at all, so it silently stopped being a video cell and came
+    // back as text — the author lost the cell, not just the URL. Keep it a video
+    // cell with an empty source: the display draws its placeholder and the
+    // editor still shows the Stream URL field to fix.
+    if (isset($cell['video'])) {
+        $v = pk_lo_stream_url($cell['video']);
+        $out['video'] = ($v !== null) ? $v : '';
+    }
     // Chip legend. A flag, not content: the denominations come from the game,
     // never from the layout file.
     if (!empty($cell['chips'])) $out['chips'] = true;

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2119');
+define('APP_VERSION', '0.2120');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Reported: pasting `http://85.237.89.160:9590/usa-s/FOX-SPORTS-1/index.m3u8` "fails and the video stream cell gets removed."

Two faults, both mine, compounding into that.

## The cell was destroyed, not just the URL

`pk_lo_cell()` set `video` **only when the URL survived validation**:

```php
if (isset($cell['video'])) { $v = pk_lo_stream_url($cell['video']); if ($v !== null) $out['video'] = $v; }
```

A rejected URL therefore left the cell with no `video` key at all, so it stopped being a video cell and came back as text. Losing a bad URL is correct; losing the cell is not.

A rejected URL now stores an empty string. The cell stays a video cell, draws its placeholder, and still offers the Stream URL field to correct.

## The editor and the server disagreed

`mediaStreamUrl()` accepted an `http` URL and **silently rewrote it to `https`**, reporting it valid. `pk_lo_stream_url()` requires the original to be `https` and rejected the same string. So the author saw a green tick, saved, and the URL was dropped — and with the bug above, the cell went with it.

That rewrite was wishful anyway: a host serving plain `http` generally has no `https` listener. I confirmed this specific host refuses TLS (`wrong version number`), so the upgraded URL could never have played.

The client now requires `https`, exactly as the server does, and the existing `diagnose()` explains why rather than just refusing.

## Verified

The same five URLs through the **shipped** client function and the **shipped** server function:

```
client                        server
reject   http://85.237.89.160:9590/.../index.m3u8    reject
reject   http://box.example.com/live.m3u8            reject
accept   https://stream.isorg.com/game/index.m3u8    accept
accept   https://cdn.example.io/clip.mp4             accept
reject   https://example.com/watch/game              reject
```

And a real save through `save_layout` with the reported URL now reads back as `{"text": ..., "video": ""}` — still a video cell.

## For the reporter

That stream is `http`-only, so it cannot be used directly: the timer page is HTTPS and browsers refuse mixed-content media. It is already available as `https://stream.isorg.com/fs1/index.m3u8`, which is the same upstream proxied with TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)