### PR TITLE
Sync the timer video across screens, and fix HLS in Chromium (v0.2121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,60 @@ All notable changes to GameNight are documented here.
 
 ---
 
+## [v0.2121] - 2026-08-28
+
+### Fixed
+
+- **The video cell never worked in Chrome or Edge.** `attachHls()` asked
+  `canPlayType('application/vnd.apple.mpegurl')` before considering hls.js, and
+  Chromium answers `"maybe"` — truthy — while being unable to demux HLS at all.
+  Every Chromium display was therefore handed the `.m3u8` directly and sat at
+  `readyState 1` forever, failing with `DEMUXER_ERROR_COULD_NOT_PARSE` and
+  `NotSupportedError: The element has no supported sources`. Safari was the only
+  browser the cell ever played in. The check is now hls.js first and native only
+  as the fallback, which is hls.js's own documented order; iOS still takes the
+  native path because it genuinely has no MSE for video.
+
+- **CSP `media-src` was missing `blob:`, blocking hls.js outright.** hls.js
+  attaches through MediaSource, and the bundled build has no `srcObject` path, so
+  the element's `src` is always a `blob:` URL that `media-src` governs. The
+  directive was written in v0.2113 for native playback and never extended, so
+  Chromium refused the attach. This hid behind the bug above and behind Safari,
+  which plays the `https:` URL natively and never builds a blob. Grants nothing
+  new: `media-src` already allows `https:`, and a `blob:` URL can only carry data
+  this origin's own script produced. Mirrors the `worker-src 'self' blob:`
+  precedent added in v0.2116 for the same library.
+
+### Added
+
+- **Several screens showing the timer now stay in sync with each other.** Two
+  browsers opening one HLS stream each join at whatever segment boundary they
+  land on and hold that offset indefinitely; hls.js cannot correct it, because it
+  steers toward its own per-client view of the live edge and ignores any gap
+  inside its tolerance. `tbStartLiveSync()` in `timer_beta.js` instead steers
+  every screen toward `now - 8s` using each segment's `#EXT-X-PROGRAM-DATE-TIME`
+  stamp, so displays converge on one another rather than merely on "live", and a
+  screen that rebuffers catches back up instead of drifting for the rest of the
+  night. Drift under 400 ms is ignored, drift up to 5 s is closed by nudging
+  `playbackRate` no more than 5-8% (pitch-corrected, so inaudible), and only a
+  larger dislocation earns a seek, which is clamped to `video.seekable`. A drift
+  beyond 120 s is treated as a wrong device clock or a stale stamp and the loop
+  stands down, since chasing it would look far worse than the drift it set out to
+  fix. hls.js's own `maxLiveSyncPlaybackRate` is disabled, because two
+  controllers pulling `playbackRate` toward different targets never settles.
+  Measured with two players started 7 s apart: a 4,770 ms gap closed to ~550 ms
+  in about a minute and then held, with both rates back at 1.0.
+
+  **Operator note:** this depends on the stream emitting
+  `#EXT-X-PROGRAM-DATE-TIME`. The `hls-game.service` unit that publishes
+  `stream.isorg.com/game/index.m3u8` was changed the same day to
+  `-hls_time 2 -hls_list_size 10` with `+program_date_time` (it had been cutting
+  10 s segments, which also capped how closely screens could ever agree). A
+  stream without those tags keeps playing; it simply gets no cross-screen
+  correction.
+
+---
+
 ## [v0.2120] - 2026-08-27
 
 ### Fixed

--- a/www/auth.php
+++ b/www/auth.php
@@ -76,7 +76,16 @@ $_csp = implode('; ', [
     "frame-ancestors 'none'",
     $_frame_src,
     $_connect_src,
-    "media-src 'self' https: data:",
+    // `blob:` for the same reason worker-src needs it: hls.js attaches to the
+    // <video> through MediaSource, and this build has no srcObject path, so the
+    // element's src is always a blob: URL that media-src governs. Without it
+    // Chromium refuses with NotSupportedError and the cell never leaves
+    // readyState 0 — while Safari, which plays HLS natively from the https: URL
+    // and never builds a blob, works fine. That split is why it went unnoticed:
+    // the directive was written in v0.2113 for native playback and hls.js was
+    // never covered. Concedes nothing extra — media-src already allows https:,
+    // and a blob: URL can only carry data this origin's own script produced.
+    "media-src 'self' https: data: blob:",
 ]);
 header("Content-Security-Policy: {$_csp}");
 if (!defined('CSP_POLICY')) define('CSP_POLICY', $_csp);

--- a/www/timer_beta.js
+++ b/www/timer_beta.js
@@ -1481,19 +1481,121 @@ function mediaStreamUrl(raw) {
 }
 
 
+/* Keeping several screens showing the SAME MOMENT.
+ *
+ * Two browsers opening one HLS stream each join at whatever segment boundary
+ * they happen to land on and then hold that offset forever, so a second display
+ * sits visibly behind the first. hls.js cannot fix this on its own: it steers
+ * toward ITS OWN view of the live edge, which is a per-client notion, and it
+ * ignores any gap inside its tolerance.
+ *
+ * The shared reference is #EXT-X-PROGRAM-DATE-TIME, which hls-game.service emits
+ * on every segment. It stamps each segment with an absolute wall-clock time, so
+ * every screen can steer toward `now - TB_SYNC_TARGET_MS` instead of toward its
+ * own arrival time. Screens then converge on each other rather than merely on
+ * "live", and a display that rebuffers catches back up instead of falling behind
+ * for the rest of the night.
+ *
+ * Corrections are gentle by default: a small drift is closed by nudging
+ * playbackRate, which is invisible, and only a real dislocation earns a seek.
+ */
+var TB_SYNC_TARGET_MS = 8000;   // where every screen aims to sit behind wall clock
+var TB_SYNC_DEAD_MS   = 400;    // close enough; leave it alone
+var TB_SYNC_SEEK_MS   = 5000;   // past this it is a dislocation, not drift: jump
+var TB_SYNC_SANE_MS   = 120000; // beyond this, distrust the input rather than act
+var TB_SYNC_EVERY_MS  = 2000;
+
+// Wall-clock time of the frame on screen right now, or null when the stream
+// carries no PDT. hls.js exposes it directly; Safari plays HLS natively and
+// instead offers the stream's start date, which currentTime is an offset from.
+function tbProgramDate(vid, h) {
+    if (h && h.playingDate) return h.playingDate;
+    if (typeof vid.getStartDate === 'function') {
+        var start = vid.getStartDate();
+        var t = start && start.getTime ? start.getTime() : NaN;
+        if (!isNaN(t)) return new Date(t + vid.currentTime * 1000);
+    }
+    return null;
+}
+
+// Steer one element toward the shared target. Returns the interval id so the
+// cache sweep can stop it when the element is disposed.
+function tbStartLiveSync(vid, h) {
+    try { vid.preservesPitch = true; } catch (e) {}
+    return setInterval(function () {
+        if (vid.paused || vid.readyState < 2 || !vid.isConnected) return;
+        var pd = tbProgramDate(vid, h);
+        if (!pd) return;
+        // Positive drift = we are BEHIND the target and must move forward.
+        var drift = (Date.now() - TB_SYNC_TARGET_MS) - pd.getTime();
+
+        // A device whose clock is wrong, or a stale PDT, produces a huge figure.
+        // Chasing it would seek endlessly and look far worse than the drift we
+        // set out to fix, so treat it as "no usable reference" and stand down.
+        if (!isFinite(drift) || Math.abs(drift) > TB_SYNC_SANE_MS) {
+            if (vid.playbackRate !== 1) { try { vid.playbackRate = 1; } catch (e) {} }
+            return;
+        }
+
+        if (Math.abs(drift) > TB_SYNC_SEEK_MS) {
+            var want = vid.currentTime + drift / 1000;
+            var sk = vid.seekable;
+            if (sk && sk.length) {
+                // Never seek outside what is actually buffered/available, or the
+                // element stalls instead of catching up.
+                want = Math.min(Math.max(want, sk.start(0) + 0.5),
+                                sk.end(sk.length - 1) - 0.5);
+            }
+            if (isFinite(want) && Math.abs(want - vid.currentTime) > 0.25) {
+                try { vid.currentTime = want; } catch (e) {}
+            }
+            try { vid.playbackRate = 1; } catch (e) {}
+            return;
+        }
+
+        if (Math.abs(drift) <= TB_SYNC_DEAD_MS) {
+            if (vid.playbackRate !== 1) { try { vid.playbackRate = 1; } catch (e) {} }
+            return;
+        }
+        // Proportional nudge. Deliberately small: pitch is corrected, so this is
+        // inaudible, and closing a couple of seconds over ~20s is imperceptible
+        // where a seek would be a visible jolt.
+        var rate = 1 + Math.max(-0.05, Math.min(0.08, drift / 15000));
+        try { vid.playbackRate = rate; } catch (e) {}
+    }, TB_SYNC_EVERY_MS);
+}
+
 // Point a <video> at a source, bringing hls.js in for .m3u8 where the browser
 // has no native HLS. Safari (and iOS in general) plays HLS directly, so it
-// never loads the library. Tuned to sit ~3 segments off the live edge and to
-// catch up by playing slightly fast rather than drifting further behind.
+// never loads the library. Live position is steered by tbStartLiveSync() against
+// the stream's PROGRAM-DATE-TIME, so several screens agree with each other and
+// not merely with their own idea of the live edge.
 function attachHls(vid, src) {
     if (!/\.m3u8(\?|$)/i.test(src)) { vid.src = src; return; }
-    if (vid.canPlayType('application/vnd.apple.mpegurl')) { vid.src = src; return; }
-    if (!window.Hls || !window.Hls.isSupported()) { vid.src = src; return; }
+    // hls.js FIRST, native only as the fallback — hls.js's own documented order,
+    // and it must be this way round. Chromium answers "maybe" to
+    // canPlayType('application/vnd.apple.mpegurl'), which is truthy, but cannot
+    // actually demux HLS: handing it the .m3u8 direct produced
+    // DEMUXER_ERROR_COULD_NOT_PARSE and "The element has no supported sources",
+    // so testing canPlayType first silently routed every Chrome and Edge display
+    // into a player that can never start. Safari was the only browser the cell
+    // ever worked in. Where MSE is genuinely absent — iOS, which has no MSE for
+    // video — isSupported() is false and the native path below still runs.
+    if (!window.Hls || !window.Hls.isSupported()) {
+        vid.src = src;
+        if (vid.canPlayType('application/vnd.apple.mpegurl')) {
+            vid._tbSync = tbStartLiveSync(vid, null);
+        }
+        return;
+    }
     var h = new window.Hls({
         lowLatencyMode: true,
         backBufferLength: 30,
         liveSyncDurationCount: 3,
-        maxLiveSyncPlaybackRate: 1.5
+        // 1 disables hls.js's own catch-up. It steers toward this client's live
+        // edge, which pulls AGAINST the wall-clock target the screens share, and
+        // two controllers fighting over playbackRate never settles.
+        maxLiveSyncPlaybackRate: 1
     });
     // A display runs unattended for hours, so a blip must not end the night.
     // These are hls.js's own documented recoveries; only an unrecoverable
@@ -1506,6 +1608,7 @@ function attachHls(vid, src) {
     });
     h.loadSource(src);
     h.attachMedia(vid);
+    vid._tbSync = tbStartLiveSync(vid, h);
     return h;
 }
 
@@ -1627,6 +1730,10 @@ function sweepVideoCache() {
             if (rec.el.paused) tbTryPlay(rec.el);
             return;
         }
+        // The sync loop outlives the element unless it is stopped here: it holds
+        // a reference to the <video>, so leaving it running leaks the element
+        // and keeps ticking against a player that no longer exists.
+        if (rec.el && rec.el._tbSync) { clearInterval(rec.el._tbSync); rec.el._tbSync = null; }
         if (rec.hls) { try { rec.hls.destroy(); } catch (e) {} }
         delete videoCache[k];
     });

--- a/www/version.php
+++ b/www/version.php
@@ -1,5 +1,5 @@
 <?php
-define('APP_VERSION', '0.2120');
+define('APP_VERSION', '0.2121');
 
 // Source for the "update available" check (public repo, no auth needed).
 // run_update_check() in db.php fetches this, regexes out APP_VERSION, and


### PR DESCRIPTION
Multiple screens showing the timer drifted apart and never re-converged. Fixing
that surfaced two more problems underneath it.

### Several screens now stay in sync with each other

Two browsers opening one HLS stream each join at whatever segment boundary they
land on and hold that offset indefinitely. hls.js cannot correct it: it steers
toward its own per-client view of the live edge and ignores any gap inside its
tolerance.

`tbStartLiveSync()` steers every screen toward `now - 8s` using each segment's
`#EXT-X-PROGRAM-DATE-TIME` stamp, so displays converge on one another rather
than merely on "live", and a screen that rebuffers catches back up instead of
drifting for the rest of the night.

- drift under 400 ms is ignored
- up to 5 s is closed by nudging `playbackRate` no more than 5-8%, pitch-corrected and inaudible
- only a larger dislocation earns a seek, clamped to `video.seekable`
- drift beyond 120 s is treated as a wrong device clock or stale stamp and the loop stands down, because chasing it looks far worse than the drift it set out to fix
- hls.js's own `maxLiveSyncPlaybackRate` is disabled: two controllers pulling `playbackRate` toward different targets never settles
- the interval is cleared in `sweepVideoCache()`, since it holds a reference to the `<video>`

Measured with two players started 7 s apart: a 4,770 ms gap closed to ~550 ms in
about a minute, then held with both rates back at 1.0.

### The video cell never worked in Chrome or Edge

`attachHls()` asked `canPlayType('application/vnd.apple.mpegurl')` before
considering hls.js. Chromium answers `"maybe"` — truthy — while being unable to
demux HLS at all, so every Chromium display was handed the `.m3u8` directly and
sat at `readyState 1` forever (`DEMUXER_ERROR_COULD_NOT_PARSE`,
`NotSupportedError: The element has no supported sources`). Safari was the only
browser the cell ever played in.

Now hls.js first, native only as the fallback — hls.js's own documented order.
iOS still takes the native path because it genuinely has no MSE for video.

### CSP `media-src` was missing `blob:`

hls.js attaches through MediaSource and the bundled build has no `srcObject`
path, so the element's `src` is always a `blob:` URL that `media-src` governs.
The directive was written in v0.2113 for native playback and never extended, so
Chromium refused the attach. This hid behind the bug above and behind Safari,
which plays the `https:` URL natively and never builds a blob.

Grants nothing new: `media-src` already allows `https:`, and a `blob:` URL can
only carry data this origin's own script produced. Mirrors the
`worker-src 'self' blob:` precedent added in v0.2116 for the same library.

### Verification

Driven headlessly against the real `timer_beta.php` page. Before: `readyState 1`,
`paused true`, never advancing. After: `readyState 4`, playing, `currentTime`
advancing, `playbackRate 1.032` with the sync loop actively steering, and no CSP
violations.

### Operator note

Cross-screen correction depends on the stream emitting
`#EXT-X-PROGRAM-DATE-TIME`. The `hls-game.service` unit publishing
`stream.isorg.com/game/index.m3u8` was changed the same day to
`-hls_time 2 -hls_list_size 10` with `+program_date_time`; it had been cutting
10 s segments, which alone capped how closely screens could ever agree. A stream
without those tags keeps playing, it simply gets no correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)